### PR TITLE
chore: fix composer run dev on Windows

### DIFF
--- a/bin/dev-logs.php
+++ b/bin/dev-logs.php
@@ -1,0 +1,9 @@
+﻿<?php
+// dev-logs.php
+// Used by `composer run dev` as the "logs" process in concurrently.
+// On Windows, keeps the slot alive; on Unix, runs pail.
+if (PHP_OS_FAMILY === 'Windows') {
+    while (true) { usleep(100000); }
+} else {
+    passthru('php artisan pail --timeout=0');
+}

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=localhost\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=localhost\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php bin/dev-logs.php\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
         ],
         "lint": [
             "pint --parallel"


### PR DESCRIPTION
## Summary

\composer run dev\ fails on Windows because \php artisan pail\ requires the \pcntl\ extension, which is Unix-only. Since the script runs with \--kill-others\, Pail's crash takes down the whole dev stack (server, queue, vite).

## Change

- Added \in/dev-logs.php\: on Windows it keeps the \logs\ slot alive as a no-op sleep loop; on Unix it delegates to \php artisan pail --timeout=0\.
- Updated the \composer.json\ \dev\ script to run \php bin/dev-logs.php\ instead of pail directly.

## Why

Concurrently kills the other processes whenever any process exits (even with code 0), so the \logs\ slot must remain running on Windows rather than no-op-and-exit.

## Testing

- \composer run dev\ brings up all four services on Windows: server (8000), queue, logs, vite (5173).