### PR TITLE
feat: display configurable app version in footer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+APP_VERSION=v2.1.0
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,6 +38,7 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'name' => config('app.name'),
+            'app_version' => config('app.version'),
             'auth' => [
                 'user' => $request->user(),
                 'can_access_admin' => $request->user()?->can('view admin') ?? false,

--- a/config/app.php
+++ b/config/app.php
@@ -15,6 +15,8 @@ return [
 
     'name' => env('APP_NAME', 'Laravel'),
 
+    'version' => env('APP_VERSION', 'v2.1.0'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Environment

--- a/resources/js/components/Footer.vue
+++ b/resources/js/components/Footer.vue
@@ -200,6 +200,17 @@ import AppLogo from './AppLogo.vue';
                 >
                     &copy; 2026 HSCStack. Built for the future of learning.
                 </p>
+
+                <div v-if="$page.props.app_version" class="flex items-center gap-2">
+                    <a
+                        :href="`https://github.com/hscstack/platform/releases/tag/${$page.props.app_version}`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 text-[11px] font-mono font-medium text-slate-500 transition-colors hover:border-slate-300 hover:text-slate-900 dark:border-gray-800 dark:bg-gray-800/60 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-200"
+                    >
+                        {{ $page.props.app_version }}
+                    </a>
+                </div>
             </div>
         </div>
     </footer>

--- a/resources/js/components/Footer.vue
+++ b/resources/js/components/Footer.vue
@@ -201,12 +201,15 @@ import AppLogo from './AppLogo.vue';
                     &copy; 2026 HSCStack. Built for the future of learning.
                 </p>
 
-                <div v-if="$page.props.app_version" class="flex items-center gap-2">
+                <div
+                    v-if="$page.props.app_version"
+                    class="flex items-center gap-2"
+                >
                     <a
                         :href="`https://github.com/hscstack/platform/releases/tag/${$page.props.app_version}`"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 text-[11px] font-mono font-medium text-slate-500 transition-colors hover:border-slate-300 hover:text-slate-900 dark:border-gray-800 dark:bg-gray-800/60 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-200"
+                        class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 font-mono text-[11px] font-medium text-slate-500 transition-colors hover:border-slate-300 hover:text-slate-900 dark:border-gray-800 dark:bg-gray-800/60 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-200"
                     >
                         {{ $page.props.app_version }}
                     </a>

--- a/resources/js/pages/User/Show.vue
+++ b/resources/js/pages/User/Show.vue
@@ -23,8 +23,8 @@ import {
     Users,
     X,
 } from 'lucide-vue-next';
-import UserListItem from '@/components/UserListItem.vue';
 import { computed, ref, watch } from 'vue';
+import UserListItem from '@/components/UserListItem.vue';
 
 const props = defineProps<{
     profileUser: {


### PR DESCRIPTION
Adds `APP_VERSION` support in `.env` and displays a subtle version badge in the footer linking to the corresponding GitHub release tag.