### PR TITLE
fix(layout): enforce min-height in AppLayout to keep footer below fold

### DIFF
--- a/resources/js/components/Footer.vue
+++ b/resources/js/components/Footer.vue
@@ -15,7 +15,7 @@ import AppLogo from './AppLogo.vue';
 
 <template>
     <footer
-        class="mt-16 border-t border-slate-100 bg-white py-12 sm:py-16 dark:border-gray-800 dark:bg-gray-900"
+        class="mt-auto border-t border-slate-100 bg-white py-12 sm:py-16 dark:border-gray-800 dark:bg-gray-900"
     >
         <div class="mx-auto max-w-7xl px-4 sm:px-6">
             <div class="grid grid-cols-1 gap-y-10 md:grid-cols-12 md:gap-x-12">

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -24,12 +24,11 @@ import ToastNotification from '@/components/ToastNotification.vue';
             ></div>
         </div>
 
-        <div class="relative z-10 flex min-h-screen flex-col justify-between">
-            <div>
-                <NavBar />
+        <div class="relative z-10 flex min-h-screen flex-col">
+            <NavBar />
+            <main class="min-h-[calc(100vh-4rem)] flex-1">
                 <slot />
-            </div>
-
+            </main>
             <Footer />
         </div>
         <FloatingShareBar />

--- a/resources/js/pages/Node.vue
+++ b/resources/js/pages/Node.vue
@@ -223,7 +223,7 @@ const handleVote = (type: 'up' | 'down') => {
     </Head>
 
     <div
-        class="mx-auto flex min-h-[calc(100vh-10rem)] w-full max-w-4xl flex-col px-4 py-8 font-sans text-slate-700 selection:bg-indigo-50 sm:px-6 md:py-12 dark:text-gray-300 dark:selection:bg-indigo-500/30"
+        class="mx-auto flex w-full max-w-4xl flex-col px-4 py-8 font-sans text-slate-700 selection:bg-indigo-50 sm:px-6 md:py-12 dark:text-gray-300 dark:selection:bg-indigo-500/30"
     >
         <BreadcrumbNav :subject="subject" :breadcrumb="breadcrumb" />
 

--- a/resources/js/pages/Resource.vue
+++ b/resources/js/pages/Resource.vue
@@ -290,7 +290,7 @@ watch(isFullscreen, (val) => {
     </Head>
 
     <div
-        class="mx-auto flex min-h-[75vh] max-w-5xl flex-col justify-start px-3 pt-3 pb-24 sm:px-6"
+        class="mx-auto flex max-w-5xl flex-col justify-start px-3 pt-3 pb-24 sm:px-6"
     >
         <!-- Flat, Minimal Media Header -->
         <div class="mb-3 flex items-center justify-between gap-3">


### PR DESCRIPTION
## Summary
- Set `min-h-[calc(100vh-4rem)]` on the main slot wrapper in `AppLayout.vue` to ensure the footer always rests below the fold on initial load regardless of content height.
- Added `mt-auto` to `Footer.vue`.
- Removed page-specific `min-h` workarounds from `Node.vue` and `Resource.vue`.