### PR TITLE
refactor(admin): optimize panel layouts and forms for mobile screen real estate

### DIFF
--- a/resources/js/layouts/AdminLayout.vue
+++ b/resources/js/layouts/AdminLayout.vue
@@ -85,7 +85,7 @@ const closeMobileSidebar = () => {
                     @close="closeMobileSidebar"
                 />
 
-                <main class="flex flex-1 flex-col overflow-x-hidden p-6 lg:p-8">
+                <main class="flex flex-1 flex-col overflow-x-hidden p-3.5 sm:p-6 lg:p-8">
                     <slot />
                 </main>
             </div>

--- a/resources/js/pages/admin/Blog.vue
+++ b/resources/js/pages/admin/Blog.vue
@@ -16,10 +16,10 @@ defineProps({
     <Head title="Manage Blogs" />
 
     <div
-        class="flex w-full flex-1 flex-col rounded-xl border border-gray-100 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+        class="flex w-full flex-1 flex-col rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-6 dark:border-gray-800 dark:bg-gray-900"
     >
         <div
-            class="mb-6 flex shrink-0 flex-col gap-4 border-b border-gray-100 pb-5 sm:flex-row sm:items-center sm:justify-between dark:border-gray-700"
+            class="mb-5 flex shrink-0 flex-col gap-3.5 border-b border-slate-100 pb-4 sm:mb-6 sm:flex-row sm:items-center sm:justify-between sm:pb-5 dark:border-gray-800"
         >
             <div>
                 <h3

--- a/resources/js/pages/admin/BlogCreateOrEdit.vue
+++ b/resources/js/pages/admin/BlogCreateOrEdit.vue
@@ -41,24 +41,22 @@ const submitForm = () => {
 <template>
     <Head :title="blog ? `Edit ${blog.title}` : 'Write Blog Post'" />
 
-    <div
-        class="flex min-h-full w-full flex-col justify-start bg-slate-50 p-6 lg:p-10 dark:bg-gray-950"
-    >
+    <div class="mx-auto w-full max-w-5xl">
         <div
-            class="mx-auto w-full max-w-4xl rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm md:p-10 dark:border-gray-700 dark:bg-gray-900"
+            class="w-full rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-8 md:p-10 dark:border-gray-800 dark:bg-gray-900"
         >
             <div
-                class="mb-8 flex flex-col justify-between gap-4 border-b border-slate-100 pb-6 sm:flex-row sm:items-center dark:border-gray-800"
+                class="mb-6 flex flex-col justify-between gap-4 border-b border-slate-100 pb-5 sm:mb-8 sm:flex-row sm:items-center sm:pb-6 dark:border-gray-800"
             >
                 <div>
                     <h1
-                        class="text-2xl font-bold text-slate-900 dark:text-gray-100"
+                        class="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl dark:text-gray-100"
                     >
                         {{ props.blog ? 'Edit' : 'Create' }} Blog Post
                     </h1>
-                    <p class="mt-1 text-sm text-slate-500 dark:text-gray-400">
+                    <p class="mt-1 text-xs text-slate-500 sm:text-sm dark:text-gray-400">
                         Compose and manage article content for your web
-                        application audience.
+                        platform.
                     </p>
                 </div>
             </div>

--- a/resources/js/pages/admin/Dashboard.vue
+++ b/resources/js/pages/admin/Dashboard.vue
@@ -19,10 +19,10 @@ defineProps({
 <template>
     <Head title="Staff Dashboard" />
 
-    <div class="animate-fade-in mx-auto max-w-7xl space-y-6 p-1">
+    <div class="animate-fade-in mx-auto w-full max-w-7xl space-y-6">
         <!-- Main Dashboard Header -->
         <div
-            class="relative overflow-hidden rounded-2xl border border-slate-300 bg-gradient-to-r from-white via-slate-50 to-white p-6 shadow-sm sm:p-8 dark:border-gray-700 dark:from-gray-900 dark:via-gray-950 dark:to-gray-900"
+            class="relative overflow-hidden rounded-2xl border border-slate-200/80 bg-gradient-to-r from-white via-slate-50 to-white p-4 shadow-xs sm:p-8 dark:border-gray-800 dark:from-gray-900 dark:via-gray-950 dark:to-gray-900"
         >
             <div
                 class="pointer-events-none absolute -top-10 -right-10 h-40 w-40 rounded-full bg-indigo-500/10 blur-3xl dark:bg-indigo-500/20"

--- a/resources/js/pages/admin/EmailSend.vue
+++ b/resources/js/pages/admin/EmailSend.vue
@@ -101,30 +101,28 @@ const submitForm = () => {
 <template>
     <Head title="Send Email" />
 
-    <div
-        class="flex min-h-full w-full flex-col justify-start bg-slate-50 p-6 lg:p-10 dark:bg-gray-950"
-    >
+    <div class="mx-auto w-full max-w-5xl">
         <div
-            class="mx-auto w-full max-w-4xl rounded-3xl border border-slate-200/80 bg-white p-6 shadow-xs md:p-10 dark:border-gray-700 dark:bg-gray-900"
+            class="w-full rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-8 md:p-10 dark:border-gray-800 dark:bg-gray-900"
         >
             <!-- Header -->
             <div
-                class="mb-8 flex flex-col justify-between gap-4 border-b border-slate-100 pb-6 sm:flex-row sm:items-center dark:border-gray-800"
+                class="mb-6 flex flex-col justify-between gap-4 border-b border-slate-100 pb-5 sm:mb-8 sm:flex-row sm:items-center sm:pb-6 dark:border-gray-800"
             >
                 <div>
                     <div class="flex items-center gap-3">
                         <div
-                            class="flex h-10 w-10 items-center justify-center rounded-2xl bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-400"
+                            class="flex h-9 w-9 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 sm:h-10 sm:w-10 dark:bg-indigo-500/10 dark:text-indigo-400"
                         >
-                            <Mail class="h-5 w-5" />
+                            <Mail class="h-4 w-4 sm:h-5 sm:w-5" />
                         </div>
                         <h1
-                            class="text-2xl font-bold text-slate-900 dark:text-gray-100"
+                            class="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl dark:text-gray-100"
                         >
                             Send Email
                         </h1>
                     </div>
-                    <p class="mt-2 text-sm text-slate-500 dark:text-gray-400">
+                    <p class="mt-1 text-xs text-slate-500 sm:text-sm dark:text-gray-400">
                         Compose and dispatch email announcements to subscribed
                         users or individual accounts.
                     </p>

--- a/resources/js/pages/admin/Index.vue
+++ b/resources/js/pages/admin/Index.vue
@@ -15,10 +15,10 @@ defineProps({
     <Head title="Manage Contents" />
 
     <div
-        class="flex w-full flex-1 flex-col rounded-xl border border-gray-100 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+        class="flex w-full flex-1 flex-col rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-6 dark:border-gray-800 dark:bg-gray-900"
     >
         <div
-            class="mb-6 flex shrink-0 flex-col gap-4 border-b border-gray-100 pb-5 sm:flex-row sm:items-center sm:justify-between dark:border-gray-700"
+            class="mb-5 flex shrink-0 flex-col gap-3.5 border-b border-slate-100 pb-4 sm:mb-6 sm:flex-row sm:items-center sm:justify-between sm:pb-5 dark:border-gray-800"
         >
             <div>
                 <h3

--- a/resources/js/pages/admin/Node.vue
+++ b/resources/js/pages/admin/Node.vue
@@ -60,10 +60,10 @@ onUnmounted(() => document.removeEventListener('click', closeDropdown));
     <Head :title="parent?.name || subject?.name || 'Manage Nodes'" />
 
     <div
-        class="flex w-full flex-1 flex-col rounded-xl border border-gray-100 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+        class="flex w-full flex-1 flex-col rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-6 dark:border-gray-800 dark:bg-gray-900"
     >
         <div
-            class="mb-6 flex shrink-0 flex-col gap-4 border-b border-gray-100 pb-5 sm:flex-row sm:items-center sm:justify-between dark:border-gray-700"
+            class="mb-5 flex shrink-0 flex-col gap-3.5 border-b border-slate-100 pb-4 sm:mb-6 sm:flex-row sm:items-center sm:justify-between sm:pb-5 dark:border-gray-800"
         >
             <div class="flex items-center gap-3">
                 <button

--- a/resources/js/pages/admin/NodeCreateOrEdit.vue
+++ b/resources/js/pages/admin/NodeCreateOrEdit.vue
@@ -49,29 +49,36 @@ const goBack = () => {
 <template>
     <Head :title="node ? `Edit ${node.name}` : 'Create Node'" />
 
-    <div
-        class="flex min-h-full w-full flex-col justify-start bg-slate-50 p-6 lg:p-10 dark:bg-gray-950"
-    >
+    <div class="mx-auto w-full max-w-5xl">
         <div
-            class="w-full rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm md:p-10 dark:border-gray-700 dark:bg-gray-900"
+            class="w-full rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-8 md:p-10 dark:border-gray-800 dark:bg-gray-900"
         >
             <div
-                class="mb-8 flex flex-col justify-between gap-4 border-b border-slate-100 pb-6 sm:flex-row sm:items-center dark:border-gray-800"
+                class="mb-6 flex flex-col justify-between gap-4 border-b border-slate-100 pb-5 sm:mb-8 sm:flex-row sm:items-center sm:pb-6 dark:border-gray-800"
             >
                 <div>
                     <h1
-                        class="text-2xl font-bold text-slate-900 dark:text-gray-100"
+                        class="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl dark:text-gray-100"
                     >
-                        {{ props.node ? 'Edit Folder' : 'Create Folder' }}
+                        {{ props.node ? 'Edit' : 'Create' }} Curriculum Node
                     </h1>
-                    <p class="mt-1 text-sm text-slate-500 dark:text-gray-400">
-                        Subject:
-                        <span
-                            class="font-semibold text-slate-700 dark:text-gray-300"
-                            >{{ props.subject?.name }}</span
-                        >
+                    <p class="mt-1 text-xs text-slate-500 sm:text-sm dark:text-gray-400">
+                        {{
+                            props.node
+                                ? 'Update node folder and hierarchy configuration.'
+                                : 'Add a new chapter or folder in ' +
+                                  (parent?.name || subject?.name) +
+                                  '.'
+                        }}
                     </p>
                 </div>
+                <button
+                    type="button"
+                    @click="goBack"
+                    class="inline-flex items-center self-start rounded-xl border border-slate-200 bg-slate-50 px-3.5 py-1.5 text-xs font-semibold text-slate-700 shadow-xs transition hover:bg-slate-100 sm:self-center dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                    &larr; Back
+                </button>
             </div>
 
             <form @submit.prevent="submitForm" class="space-y-8">

--- a/resources/js/pages/admin/NoticeEdit.vue
+++ b/resources/js/pages/admin/NoticeEdit.vue
@@ -61,21 +61,19 @@ const submitForm = () => {
 <template>
     <Head title="Site Notice" />
 
-    <div
-        class="flex min-h-full w-full flex-col justify-start bg-slate-50 p-6 lg:p-10 dark:bg-gray-950"
-    >
+    <div class="mx-auto w-full max-w-5xl">
         <div
-            class="w-full rounded-3xl bg-white p-6 shadow-xs ring-1 ring-slate-900/5 md:p-10 dark:bg-gray-900 dark:ring-gray-700"
+            class="w-full rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-8 md:p-10 dark:border-gray-800 dark:bg-gray-900"
         >
             <div
-                class="mb-10 border-b border-slate-100 pb-6 dark:border-gray-800"
+                class="mb-6 border-b border-slate-100 pb-5 sm:mb-8 sm:pb-6 dark:border-gray-800"
             >
                 <h1
-                    class="text-2xl font-bold tracking-tight text-slate-900 dark:text-gray-100"
+                    class="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl dark:text-gray-100"
                 >
                     Site Notice
                 </h1>
-                <p class="mt-1 text-sm text-slate-500 dark:text-gray-400">
+                <p class="mt-1 text-xs text-slate-500 sm:text-sm dark:text-gray-400">
                     Configure the announcement dialog shown on the home page.
                     Only one notice is displayed at a time.
                 </p>

--- a/resources/js/pages/admin/ResourceCreateOrEdit.vue
+++ b/resources/js/pages/admin/ResourceCreateOrEdit.vue
@@ -91,22 +91,20 @@ const submitForm = () => {
         "
     />
 
-    <div
-        class="flex min-h-full w-full flex-col justify-start bg-slate-50 p-6 lg:p-10 dark:bg-gray-950"
-    >
+    <div class="mx-auto w-full max-w-5xl">
         <div
-            class="mx-auto w-full max-w-4xl rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm md:p-10 dark:border-gray-700/80 dark:bg-gray-900"
+            class="w-full rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-8 md:p-10 dark:border-gray-800 dark:bg-gray-900"
         >
             <div
-                class="mb-8 flex flex-col justify-between gap-4 border-b border-slate-100 pb-6 sm:flex-row sm:items-center dark:border-gray-800"
+                class="mb-6 flex flex-col justify-between gap-4 border-b border-slate-100 pb-5 sm:mb-8 sm:flex-row sm:items-center sm:pb-6 dark:border-gray-800"
             >
                 <div>
                     <h1
-                        class="text-2xl font-bold text-slate-900 dark:text-gray-100"
+                        class="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl dark:text-gray-100"
                     >
                         {{ props.resource ? 'Edit' : 'Add New' }} Resource
                     </h1>
-                    <p class="mt-1 text-sm text-slate-500 dark:text-gray-400">
+                    <p class="mt-1 text-xs text-slate-500 sm:text-sm dark:text-gray-400">
                         Upload assets or link content for the curriculum
                         structure.
                     </p>

--- a/resources/js/pages/admin/SubjectCreateOrEdit.vue
+++ b/resources/js/pages/admin/SubjectCreateOrEdit.vue
@@ -72,22 +72,20 @@ const submitForm = () => {
 <template>
     <Head :title="subject ? `Edit ${subject.name}` : 'Create Subject'" />
 
-    <div
-        class="flex min-h-full w-full flex-col justify-start bg-slate-50 p-6 lg:p-10 dark:bg-gray-950"
-    >
+    <div class="mx-auto w-full max-w-5xl">
         <div
-            class="w-full rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm md:p-10 dark:border-gray-700 dark:bg-gray-900"
+            class="w-full rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-8 md:p-10 dark:border-gray-800 dark:bg-gray-900"
         >
             <div
-                class="mb-8 flex flex-col justify-between gap-4 border-b border-slate-100 pb-6 sm:flex-row sm:items-center dark:border-gray-800"
+                class="mb-6 flex flex-col justify-between gap-4 border-b border-slate-100 pb-5 sm:mb-8 sm:flex-row sm:items-center sm:pb-6 dark:border-gray-800"
             >
                 <div>
                     <h1
-                        class="text-2xl font-bold text-slate-900 dark:text-gray-100"
+                        class="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl dark:text-gray-100"
                     >
                         {{ props.subject ? 'Edit' : 'Create' }} New Subject
                     </h1>
-                    <p class="mt-1 text-sm text-slate-500 dark:text-gray-400">
+                    <p class="mt-1 text-xs text-slate-500 sm:text-sm dark:text-gray-400">
                         {{
                             props.subject
                                 ? 'Update the subject details below.'
@@ -98,7 +96,7 @@ const submitForm = () => {
                 <button
                     type="button"
                     @click="goBack"
-                    class="inline-flex items-center self-start rounded-lg bg-slate-100 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-200 sm:self-center dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
+                    class="inline-flex items-center self-start rounded-xl border border-slate-200 bg-slate-50 px-3.5 py-1.5 text-xs font-semibold text-slate-700 shadow-xs transition hover:bg-slate-100 sm:self-center dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
                 >
                     &larr; Back
                 </button>

--- a/resources/js/pages/admin/resources/BulkImageCreate.vue
+++ b/resources/js/pages/admin/resources/BulkImageCreate.vue
@@ -133,25 +133,23 @@ const submitForm = () => {
 <template>
     <Head title="Bulk Upload Images" />
 
-    <div
-        class="flex min-h-full w-full flex-col justify-start bg-slate-50 p-6 lg:p-10 dark:bg-gray-950"
-    >
+    <div class="mx-auto w-full max-w-5xl">
         <div
-            class="mx-auto w-full max-w-4xl rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm md:p-10 dark:border-gray-700 dark:bg-gray-900"
+            class="w-full rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-8 md:p-10 dark:border-gray-800 dark:bg-gray-900"
         >
             <!-- Header -->
             <div
-                class="mb-8 flex flex-col justify-between gap-4 border-b border-slate-100 pb-6 sm:flex-row sm:items-center dark:border-gray-800"
+                class="mb-6 flex flex-col justify-between gap-4 border-b border-slate-100 pb-5 sm:mb-8 sm:flex-row sm:items-center sm:pb-6 dark:border-gray-800"
             >
                 <div>
                     <h1
-                        class="text-2xl font-bold text-slate-900 dark:text-gray-100"
+                        class="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl dark:text-gray-100"
                     >
                         Bulk Upload Images
                     </h1>
-                    <p class="mt-1 text-sm text-slate-500 dark:text-gray-400">
-                        Upload multiple image resources simultaneously and
-                        configure naming conventions.
+                    <p class="mt-1 text-xs text-slate-500 sm:text-sm dark:text-gray-400">
+                        Upload multiple images directly to this chapter or
+                        folder at once.
                     </p>
                 </div>
             </div>

--- a/resources/js/pages/admin/resources/BulkVideoCreate.vue
+++ b/resources/js/pages/admin/resources/BulkVideoCreate.vue
@@ -35,23 +35,21 @@ const submitForm = () => {
 <template>
     <Head title="Import YouTube Playlist" />
 
-    <div
-        class="flex min-h-full w-full flex-col justify-start bg-slate-50 p-6 lg:p-10 dark:bg-gray-950"
-    >
+    <div class="mx-auto w-full max-w-5xl">
         <div
-            class="mx-auto w-full max-w-4xl rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm md:p-10 dark:border-gray-700 dark:bg-gray-900"
+            class="w-full rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-8 md:p-10 dark:border-gray-800 dark:bg-gray-900"
         >
             <!-- Header -->
             <div
-                class="mb-8 flex flex-col justify-between gap-4 border-b border-slate-100 pb-6 sm:flex-row sm:items-center dark:border-gray-800"
+                class="mb-6 flex flex-col justify-between gap-4 border-b border-slate-100 pb-5 sm:mb-8 sm:flex-row sm:items-center sm:pb-6 dark:border-gray-800"
             >
                 <div>
                     <h1
-                        class="text-2xl font-bold text-slate-900 dark:text-gray-100"
+                        class="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl dark:text-gray-100"
                     >
                         Import YouTube Playlist
                     </h1>
-                    <p class="mt-1 text-sm text-slate-500 dark:text-gray-400">
+                    <p class="mt-1 text-xs text-slate-500 sm:text-sm dark:text-gray-400">
                         Automatically fetch videos from a YouTube playlist and
                         create resources preserving playlist order.
                     </p>

--- a/resources/js/pages/admin/users/CreateOrEdit.vue
+++ b/resources/js/pages/admin/users/CreateOrEdit.vue
@@ -63,22 +63,20 @@ const submitForm = () => {
 <template>
     <Head :title="user ? `Edit ${user.name}` : 'Create User'" />
 
-    <div
-        class="mobile-deep-border:p-4 flex min-h-full w-full flex-col justify-start bg-slate-50 p-4 lg:p-10 dark:bg-gray-950"
-    >
+    <div class="mx-auto w-full max-w-5xl">
         <div
-            class="w-full rounded-2xl border border-gray-300 bg-white p-5 shadow-xs md:p-10 dark:border-gray-600 dark:bg-gray-900"
+            class="w-full rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-8 md:p-10 dark:border-gray-800 dark:bg-gray-900"
         >
             <div
-                class="mb-8 flex flex-col justify-between gap-4 border-b border-gray-300 pb-6 sm:flex-row sm:items-center dark:border-gray-600"
+                class="mb-6 flex flex-col justify-between gap-4 border-b border-slate-100 pb-5 sm:mb-8 sm:flex-row sm:items-center sm:pb-6 dark:border-gray-800"
             >
                 <div>
                     <h1
-                        class="text-2xl font-bold text-slate-900 dark:text-gray-100"
+                        class="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl dark:text-gray-100"
                     >
                         {{ props.user ? 'Edit' : 'Create New' }} User
                     </h1>
-                    <p class="mt-1 text-sm text-slate-500 dark:text-gray-400">
+                    <p class="mt-1 text-xs text-slate-500 sm:text-sm dark:text-gray-400">
                         {{
                             props.user
                                 ? 'Update team member details and system access rules.'

--- a/resources/js/pages/admin/users/Index.vue
+++ b/resources/js/pages/admin/users/Index.vue
@@ -13,10 +13,10 @@ defineProps({
     <Head title="Manage Users" />
 
     <div
-        class="flex w-full flex-1 flex-col rounded-xl border border-gray-300 bg-white p-4 shadow-xs sm:p-6 dark:border-gray-600 dark:bg-gray-900"
+        class="flex w-full flex-1 flex-col rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs sm:p-6 dark:border-gray-800 dark:bg-gray-900"
     >
         <div
-            class="mb-6 flex shrink-0 flex-col gap-4 border-b border-gray-300 pb-5 sm:flex-row sm:items-center sm:justify-between dark:border-gray-600"
+            class="mb-5 flex shrink-0 flex-col gap-3.5 border-b border-slate-100 pb-4 sm:mb-6 sm:flex-row sm:items-center sm:justify-between sm:pb-5 dark:border-gray-800"
         >
             <div>
                 <h3


### PR DESCRIPTION
### Summary
- **Mobile Real Estate**: Reduced excessive padding in `AdminLayout.vue` (`p-3.5 sm:p-6 lg:p-8`) to maximize available viewport width on mobile devices.
- **Removed Nested Wrappers**: Cleaned up duplicated outer containers (`bg-slate-50 p-6 lg:p-10`) from all admin edit/create pages.
- **Responsive Card Padding**: Standardized card padding across index and create/edit forms (`p-4 sm:p-8 md:p-10`) so input fields, buttons, and tables don't get squished by outer margins on phones.
- **Affected Pages**:
  - `AdminLayout.vue`
  - `Dashboard.vue`
  - `Index.vue` (Subjects)
  - `SubjectCreateOrEdit.vue`
  - `Node.vue`
  - `NodeCreateOrEdit.vue`
  - `ResourceCreateOrEdit.vue`
  - `BulkImageCreate.vue` & `BulkVideoCreate.vue`
  - `Blog.vue` & `BlogCreateOrEdit.vue`
  - `NoticeEdit.vue`
  - `users/Index.vue` & `users/CreateOrEdit.vue`
  - `EmailSend.vue`