### PR TITLE
fix: use default storage disk for tickets and fix dark mode input focus

### DIFF
--- a/app/Http/Controllers/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Admin/SupportTicketController.php
@@ -108,7 +108,7 @@ class SupportTicketController extends Controller
     public function destroy(SupportTicket $ticket)
     {
         if ($ticket->attachment_path && ! str($ticket->attachment_path)->startsWith(['http://', 'https://'])) {
-            Storage::disk('public')->delete($ticket->attachment_path);
+            Storage::delete($ticket->attachment_path);
         }
 
         $ticket->delete();

--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -76,7 +76,7 @@ class SupportTicketController extends Controller
 
         $attachmentPath = null;
         if ($request->hasFile('attachment')) {
-            $attachmentPath = $request->file('attachment')->store('tickets', 'public');
+            $attachmentPath = $request->file('attachment')->store('tickets');
         }
 
         $ticket = SupportTicket::create([

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -26,6 +26,11 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @layer base {
+    html.dark,
+    .dark {
+        color-scheme: dark;
+    }
+
     html,
     body {
         font-stretch: 96%;
@@ -44,6 +49,23 @@
     * {
         scrollbar-width: none; /* Firefox */
         -ms-overflow-style: none; /* IE and Edge */
+    }
+
+    /* Prevent browser autofill from whiting out in dark mode */
+    .dark input:-webkit-autofill,
+    .dark input:-webkit-autofill:hover,
+    .dark input:-webkit-autofill:focus,
+    .dark textarea:-webkit-autofill,
+    .dark textarea:-webkit-autofill:hover,
+    .dark textarea:-webkit-autofill:focus,
+    .dark select:-webkit-autofill,
+    .dark select:-webkit-autofill:hover,
+    .dark select:-webkit-autofill:focus {
+        -webkit-text-fill-color: rgb(243 244 246) !important;
+        -webkit-box-shadow: 0 0 0px 1000px rgb(17 24 39) inset !important;
+        box-shadow: 0 0 0px 1000px rgb(17 24 39) inset !important;
+        caret-color: rgb(243 244 246) !important;
+        transition: background-color 5000s ease-in-out 0s;
     }
 }
 

--- a/resources/js/pages/Blog/Index.vue
+++ b/resources/js/pages/Blog/Index.vue
@@ -69,7 +69,7 @@ const clearSearch = () => {
                             type="text"
                             placeholder="আর্টিকেল খুঁজুন..."
                             @keyup.enter="handleSearch"
-                            class="w-full rounded-xl border border-slate-200 py-3 pr-10 pl-11 text-sm text-slate-900 shadow-sm transition-all placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
+                            class="w-full rounded-xl border border-slate-200 bg-white py-3 pr-10 pl-11 text-sm text-slate-900 shadow-sm transition-all placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                         />
 
                         <button

--- a/resources/js/pages/admin/BlogCreateOrEdit.vue
+++ b/resources/js/pages/admin/BlogCreateOrEdit.vue
@@ -70,7 +70,7 @@ const submitForm = () => {
                     type="text"
                     id="title"
                     placeholder="e.g. 10 Tips for Cracking BUET"
-                    class="w-full rounded-lg border px-4 py-2.5 transition outline-none"
+                    class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                     :class="
                         form.errors.title
                             ? 'border-rose-500 focus:ring-rose-500/20'
@@ -145,7 +145,7 @@ const submitForm = () => {
                     type="text"
                     id="seo_tags"
                     placeholder="e.g. admission, news, tips"
-                    class="w-full rounded-lg border px-4 py-2.5 transition outline-none"
+                    class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                     :class="
                         form.errors.seo_tags
                             ? 'border-rose-500 focus:ring-rose-500/20'

--- a/resources/js/pages/admin/EmailSend.vue
+++ b/resources/js/pages/admin/EmailSend.vue
@@ -344,7 +344,7 @@ const submitForm = () => {
                         required
                         placeholder="user@example.com"
                         :disabled="form.processing"
-                        class="w-full rounded-xl border py-3 pr-4 pl-10 text-sm transition outline-none focus:ring-4 dark:bg-gray-950 dark:text-gray-100"
+                        class="w-full rounded-xl border bg-white py-3 pr-4 pl-10 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 focus:ring-4 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
                         :class="
                             form.errors.recipient_email
                                 ? 'border-rose-300 focus:border-rose-500 focus:ring-rose-500/10'
@@ -392,7 +392,7 @@ const submitForm = () => {
                     required
                     placeholder="e.g. Important Announcement: New Resources & Learning Updates"
                     :disabled="form.processing"
-                    class="w-full rounded-xl border px-4 py-3 text-sm transition outline-none focus:ring-4 dark:bg-gray-950 dark:text-gray-100"
+                    class="w-full rounded-xl border bg-white px-4 py-3 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 focus:ring-4 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
                     :class="
                         form.errors.subject
                             ? 'border-rose-300 focus:border-rose-500 focus:ring-rose-500/10'

--- a/resources/js/pages/admin/NoticeEdit.vue
+++ b/resources/js/pages/admin/NoticeEdit.vue
@@ -88,7 +88,7 @@ const submitForm = () => {
                         id="title"
                         placeholder="Important announcement"
                         :disabled="form.processing"
-                        class="w-full rounded-xl border px-4 py-3 text-sm transition outline-none focus:ring-4 disabled:bg-slate-50 disabled:text-slate-400 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-500"
+                        class="w-full rounded-xl border bg-white px-4 py-3 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 focus:ring-4 disabled:bg-slate-50 disabled:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-500"
                         :class="
                             form.errors.title
                                 ? 'border-rose-300 focus:border-rose-500 focus:ring-rose-500/10'
@@ -116,7 +116,7 @@ const submitForm = () => {
                         rows="6"
                         placeholder="Write the notice message for visitors..."
                         :disabled="form.processing"
-                        class="w-full rounded-xl border px-4 py-3 text-sm transition outline-none focus:ring-4 disabled:bg-slate-50 disabled:text-slate-400 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-500"
+                        class="w-full rounded-xl border bg-white px-4 py-3 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 focus:ring-4 disabled:bg-slate-50 disabled:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-500"
                         :class="
                             form.errors.message
                                 ? 'border-rose-300 focus:border-rose-500 focus:ring-rose-500/10'
@@ -179,7 +179,7 @@ const submitForm = () => {
                                 id="button_title"
                                 placeholder="Learn more"
                                 :disabled="form.processing"
-                                class="w-full rounded-xl border bg-white px-4 py-2.5 text-sm transition outline-none focus:ring-4 dark:bg-gray-900"
+                                class="w-full rounded-xl border bg-white px-4 py-2.5 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 focus:ring-4 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                                 :class="
                                     form.errors.button_title
                                         ? 'border-rose-300 focus:border-rose-500 focus:ring-rose-500/10'
@@ -207,7 +207,7 @@ const submitForm = () => {
                                 id="button_link"
                                 placeholder="https://example.com/details"
                                 :disabled="form.processing"
-                                class="w-full rounded-xl border bg-white px-4 py-2.5 text-sm transition outline-none focus:ring-4 dark:bg-gray-900"
+                                class="w-full rounded-xl border bg-white px-4 py-2.5 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 focus:ring-4 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                                 :class="
                                     form.errors.button_link
                                         ? 'border-rose-300 focus:border-rose-500 focus:ring-rose-500/10'

--- a/resources/js/pages/admin/ResourceCreateOrEdit.vue
+++ b/resources/js/pages/admin/ResourceCreateOrEdit.vue
@@ -169,7 +169,7 @@ const submitForm = () => {
                     id="title"
                     placeholder="e.g. Lecture 01 Introduction Notes"
                     maxlength="100"
-                    class="w-full rounded-lg border px-4 py-2.5 transition outline-none"
+                    class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                     :class="
                         form.errors.title
                             ? 'border-rose-500 focus:ring-rose-500/20'
@@ -197,7 +197,7 @@ const submitForm = () => {
                     id="content"
                     rows="3"
                     placeholder="Type notes, descriptions, or body text..."
-                    class="w-full rounded-lg border px-4 py-2.5 font-sans transition outline-none"
+                    class="w-full rounded-lg border bg-white px-4 py-2.5 font-sans text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                     :class="
                         form.errors.content
                             ? 'border-rose-500 focus:ring-rose-500/20'
@@ -237,7 +237,7 @@ const submitForm = () => {
                                 ? 'e.g. https://example.com/document.pdf'
                                 : 'e.g. https://www.youtube.com/watch?v=... or Vimeo URL'
                         "
-                        class="w-full rounded-lg border py-2.5 pr-4 pl-11 transition outline-none"
+                        class="w-full rounded-lg border bg-white py-2.5 pr-4 pl-11 text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                         :class="
                             form.errors.external_url
                                 ? 'border-rose-500 focus:ring-rose-500/20'

--- a/resources/js/pages/admin/SubjectCreateOrEdit.vue
+++ b/resources/js/pages/admin/SubjectCreateOrEdit.vue
@@ -114,11 +114,11 @@ const submitForm = () => {
                         type="text"
                         id="name"
                         placeholder="e.g. পদার্থবিজ্ঞান ১ম পত্র"
-                        class="w-full rounded-lg border px-4 py-2.5 transition outline-none"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                         :class="
                             form.errors.name
                                 ? 'border-rose-500 focus:ring-rose-500/20'
-                                : 'border-slate-300 focus:border-blue-500 focus:ring-blue-500/20 dark:border-gray-600 dark:bg-gray-900'
+                                : 'border-slate-300 focus:border-blue-500 focus:ring-blue-500/20 dark:border-gray-600'
                         "
                     />
                     <p
@@ -138,7 +138,7 @@ const submitForm = () => {
                     <select
                         v-model="form.course"
                         id="course"
-                        class="w-full rounded-lg border bg-white px-4 py-2.5 transition outline-none dark:bg-gray-900"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none dark:bg-gray-900 dark:text-gray-100"
                         :class="
                             form.errors.course
                                 ? 'border-rose-500 focus:ring-rose-500/20'
@@ -205,16 +205,16 @@ const submitForm = () => {
                                 type="text"
                                 id="english_name"
                                 placeholder="e.g. Physics 1st Paper, Bangla"
-                                class="w-full rounded-lg border px-3.5 py-2 text-sm transition outline-none"
+                                class="w-full rounded-lg border bg-white px-3.5 py-2 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                                 :class="
                                     form.errors.english_name
                                         ? 'border-rose-500 focus:ring-rose-500/20'
-                                        : 'border-slate-300 focus:border-blue-500 focus:ring-blue-500/20 dark:border-gray-600 dark:bg-gray-900'
+                                        : 'border-slate-300 focus:border-blue-500 focus:ring-blue-500/20 dark:border-gray-600'
                                 "
                             />
                             <p
                                 v-if="form.errors.english_name"
-                                class="mt-1 text-xs text-rose-600"
+                                class="mt-1 text-sm text-rose-600"
                             >
                                 {{ form.errors.english_name }}
                             </p>
@@ -238,16 +238,16 @@ const submitForm = () => {
                                 v-model.number="form.sort_order"
                                 type="number"
                                 id="sort_order"
-                                class="w-full rounded-lg border px-3.5 py-2 text-sm transition outline-none"
+                                class="w-full rounded-lg border bg-white px-3.5 py-2 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                                 :class="
                                     form.errors.sort_order
                                         ? 'border-rose-500 focus:ring-rose-500/20'
-                                        : 'border-slate-300 focus:border-blue-500 focus:ring-blue-500/20 dark:border-gray-600 dark:bg-gray-900'
+                                        : 'border-slate-300 focus:border-blue-500 focus:ring-blue-500/20 dark:border-gray-600'
                                 "
                             />
                             <p
                                 v-if="form.errors.sort_order"
-                                class="mt-1 text-xs text-rose-600"
+                                class="mt-1 text-sm text-rose-600"
                             >
                                 {{ form.errors.sort_order }}
                             </p>
@@ -276,11 +276,11 @@ const submitForm = () => {
                             type="text"
                             id="slug"
                             placeholder="e.g., hsc-physics-1st-paper (leave blank to auto-generate)"
-                            class="w-full rounded-lg border px-3.5 py-2 text-sm transition outline-none"
+                            class="w-full rounded-lg border bg-white px-3.5 py-2 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                             :class="
                                 form.errors.slug
                                     ? 'border-rose-500 focus:ring-rose-500/20'
-                                    : 'border-slate-300 focus:border-blue-500 focus:ring-blue-500/20 dark:border-gray-600 dark:bg-gray-900'
+                                    : 'border-slate-300 focus:border-blue-500 focus:ring-blue-500/20 dark:border-gray-600'
                             "
                         />
                         <p

--- a/resources/js/pages/admin/resources/BulkImageCreate.vue
+++ b/resources/js/pages/admin/resources/BulkImageCreate.vue
@@ -323,7 +323,7 @@ const submitForm = () => {
                             v-model="form.naming_prefix"
                             type="text"
                             placeholder="e.g. image"
-                            class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-gray-600 dark:bg-gray-900"
+                            class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none placeholder:text-slate-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                         />
                         <p
                             class="mt-1 text-[11px] text-slate-400 dark:text-gray-500"
@@ -344,7 +344,7 @@ const submitForm = () => {
                             type="number"
                             min="1"
                             placeholder="1"
-                            class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-gray-600 dark:bg-gray-900"
+                            class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none placeholder:text-slate-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                         />
                         <p
                             class="mt-1 text-[11px] text-slate-400 dark:text-gray-500"

--- a/resources/js/pages/admin/resources/BulkVideoCreate.vue
+++ b/resources/js/pages/admin/resources/BulkVideoCreate.vue
@@ -78,7 +78,7 @@ const submitForm = () => {
                         id="playlist_url"
                         placeholder="https://www.youtube.com/playlist?list=PL..."
                         required
-                        class="w-full rounded-lg border py-2.5 pr-4 pl-11 text-sm transition outline-none"
+                        class="w-full rounded-lg border bg-white py-2.5 pr-4 pl-11 text-sm text-slate-900 transition outline-none placeholder:text-slate-400 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
                         :class="
                             form.errors.playlist_url
                                 ? 'border-rose-500 focus:ring-2 focus:ring-rose-500/20'

--- a/resources/js/pages/admin/users/CreateOrEdit.vue
+++ b/resources/js/pages/admin/users/CreateOrEdit.vue
@@ -102,7 +102,7 @@ const submitForm = () => {
                         id="name"
                         placeholder="John Doe"
                         :disabled="form.processing"
-                        class="w-full rounded-lg border px-4 py-2.5 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                         :class="
                             form.errors.name
                                 ? 'border-rose-500 focus:ring-rose-500/20'
@@ -134,7 +134,7 @@ const submitForm = () => {
                             id="username"
                             placeholder="johndoe"
                             :disabled="form.processing"
-                            class="w-full rounded-lg border py-2.5 pr-4 pl-8 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                            class="w-full rounded-lg border bg-white py-2.5 pr-4 pl-8 text-slate-900 transition outline-none placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                             :class="
                                 form.errors.username
                                     ? 'border-rose-500 focus:ring-rose-500/20'
@@ -162,7 +162,7 @@ const submitForm = () => {
                         id="email"
                         placeholder="johndoe@example.com"
                         :disabled="form.processing"
-                        class="w-full rounded-lg border px-4 py-2.5 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                         :class="
                             form.errors.email
                                 ? 'border-rose-500 focus:ring-rose-500/20'
@@ -190,7 +190,7 @@ const submitForm = () => {
                         id="role"
                         v-model="form.role"
                         :disabled="form.processing"
-                        class="w-full rounded-lg border bg-white px-4 py-2.5 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                         :class="
                             form.errors.role
                                 ? 'border-rose-500 focus:ring-rose-500/20'
@@ -315,7 +315,7 @@ const submitForm = () => {
                         id="title"
                         placeholder="e.g. Lead Developer, Professor"
                         :disabled="form.processing"
-                        class="w-full rounded-lg border px-4 py-2.5 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                         :class="
                             form.errors.title
                                 ? 'border-rose-500 focus:ring-rose-500/20'
@@ -344,7 +344,7 @@ const submitForm = () => {
                         id="institution"
                         placeholder="University / Company"
                         :disabled="form.processing"
-                        class="w-full rounded-lg border px-4 py-2.5 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                         :class="
                             form.errors.institution
                                 ? 'border-rose-500 focus:ring-rose-500/20'
@@ -371,7 +371,7 @@ const submitForm = () => {
                         id="facebook"
                         placeholder="Facebook profile URL"
                         :disabled="form.processing"
-                        class="w-full rounded-lg border px-4 py-2.5 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                         :class="
                             form.errors.facebook
                                 ? 'border-rose-500 focus:ring-rose-500/20'
@@ -400,7 +400,7 @@ const submitForm = () => {
                         id="github"
                         placeholder="GitHub profile URL"
                         :disabled="form.processing"
-                        class="w-full rounded-lg border px-4 py-2.5 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                         :class="
                             form.errors.github
                                 ? 'border-rose-500 focus:ring-rose-500/20'
@@ -427,7 +427,7 @@ const submitForm = () => {
                         id="instagram"
                         placeholder="Instagram profile URL"
                         :disabled="form.processing"
-                        class="w-full rounded-lg border px-4 py-2.5 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                        class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                         :class="
                             form.errors.instagram
                                 ? 'border-rose-500 focus:ring-rose-500/20'
@@ -455,7 +455,7 @@ const submitForm = () => {
                     rows="4"
                     placeholder="Short bio..."
                     :disabled="form.processing"
-                    class="w-full rounded-lg border px-4 py-2.5 transition outline-none disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
+                    class="w-full rounded-lg border bg-white px-4 py-2.5 text-slate-900 transition outline-none placeholder:text-slate-400 disabled:bg-slate-50 disabled:text-slate-500 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:text-gray-400"
                     :class="
                         form.errors.about
                             ? 'border-rose-500 focus:ring-rose-500/20'

--- a/resources/js/pages/admin/users/Index.vue
+++ b/resources/js/pages/admin/users/Index.vue
@@ -101,7 +101,7 @@ const clearSearch = () => {
                         type="text"
                         placeholder="Search name, email, username..."
                         @keyup.enter="handleSearch"
-                        class="w-full appearance-none rounded-xl border border-slate-200 bg-slate-50 py-1.5 pr-8 pl-9 text-xs font-semibold text-slate-800 placeholder:text-slate-400 focus:border-indigo-500 focus:bg-white focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-indigo-400"
+                        class="w-full appearance-none rounded-xl border border-slate-200 bg-slate-50 py-1.5 pr-8 pl-9 text-xs font-semibold text-slate-800 placeholder:text-slate-400 focus:border-indigo-500 focus:bg-white focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-indigo-400 dark:focus:bg-gray-900"
                     />
                     <Search
                         class="pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-slate-400"

--- a/tests/Feature/SupportTicketTest.php
+++ b/tests/Feature/SupportTicketTest.php
@@ -18,7 +18,7 @@ test('support and donate pages load successfully', function () {
 });
 
 test('authenticated user can submit a support ticket and receive email', function () {
-    Storage::fake('public');
+    Storage::fake();
     Mail::fake();
     $user = User::factory()->create();
 
@@ -44,7 +44,7 @@ test('authenticated user can submit a support ticket and receive email', functio
     expect($ticket->ticket_number)->toStartWith('TKT-')
         ->and($ticket->attachment_path)->not->toBeNull();
 
-    Storage::disk('public')->assertExists($ticket->attachment_path);
+    Storage::assertExists($ticket->attachment_path);
 
     Mail::assertQueued(SupportTicketMail::class, function ($mail) use ($user, $ticket) {
         return $mail->hasTo($user->email) && $mail->mailSubject === "[HSCStack Support] Ticket #{$ticket->ticket_number} Received";
@@ -156,13 +156,13 @@ test('admin can reply to a ticket and resolve it', function () {
 });
 
 test('admin can update status and delete a ticket', function () {
-    Storage::fake('public');
+    Storage::fake();
     Mail::fake();
     $admin = User::factory()->create();
     $admin->assignRole('admin');
 
     $file = UploadedFile::fake()->image('error.jpg');
-    $path = $file->store('tickets', 'public');
+    $path = $file->store('tickets');
 
     $ticket = SupportTicket::create([
         'user_id' => $admin->id,
@@ -193,7 +193,7 @@ test('admin can update status and delete a ticket', function () {
         ->assertSessionHas('success');
 
     expect(SupportTicket::count())->toBe(0);
-    Storage::disk('public')->assertMissing($path);
+    Storage::assertMissing($path);
 });
 
 test('non-admin user cannot access admin ticket management', function () {


### PR DESCRIPTION
### Summary of changes
- **Storage Disk**: Removed hardcoded `'public'` disk in `SupportTicketController` to use the default configured disk (`FILESYSTEM_DISK`), matching the rest of the application.
- **Dark Mode Input Fix**: Added `color-scheme: dark;` and `-webkit-autofill` overrides in `app.css` to prevent browser autocomplete/autofill from whiting out input backgrounds in dark mode.
- **Form Inputs Styling**: Added missing `dark:focus:bg-gray-900` and explicit dark background/text color classes across admin and public forms.