### PR TITLE
feat(seo): complete SEO optimization with rich schema, canonical tags, and comprehensive sitemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /public/hot
 /public/storage
 /public/local
+/public/sitemap.xml
 /resources/js/actions
 /resources/js/routes
 /resources/js/wayfinder

--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -3,7 +3,9 @@
 namespace App\Console\Commands;
 
 use App\Models\Blog;
+use App\Models\Node;
 use App\Models\Subject;
+use App\Models\User;
 use Illuminate\Console\Command;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\Tags\Url;
@@ -12,48 +14,113 @@ class GenerateSitemap extends Command
 {
     protected $signature = 'seo:sitemap';
 
-    protected $description = 'Generate sitemap.xml';
+    protected $description = 'Generate sitemap.xml with static pages, subjects, curriculum nodes, blogs, and active user profiles.';
 
     public function handle(): int
     {
         $sitemap = Sitemap::create();
 
-        // Static pages
-        foreach (
-            [
-                '/',
-                '/ssc',
-                '/blogs',
-                '/about-us',
-                '/privacy-policy',
-                '/terms-service',
-                '/content-policy',
-                '/donate',
-                '/join',
-                '/guide',
-            ] as $page
-        ) {
+        // 1. Static Pages
+        $staticPages = [
+            '/' => ['priority' => 1.0, 'freq' => 'daily'],
+            '/ssc' => ['priority' => 0.9, 'freq' => 'daily'],
+            '/blogs' => ['priority' => 0.8, 'freq' => 'daily'],
+            '/about-us' => ['priority' => 0.7, 'freq' => 'monthly'],
+            '/projects' => ['priority' => 0.7, 'freq' => 'monthly'],
+            '/guide' => ['priority' => 0.7, 'freq' => 'monthly'],
+            '/ai' => ['priority' => 0.7, 'freq' => 'monthly'],
+            '/donate' => ['priority' => 0.6, 'freq' => 'monthly'],
+            '/join' => ['priority' => 0.6, 'freq' => 'monthly'],
+            '/login' => ['priority' => 0.5, 'freq' => 'monthly'],
+            '/support' => ['priority' => 0.5, 'freq' => 'monthly'],
+            '/privacy-policy' => ['priority' => 0.3, 'freq' => 'yearly'],
+            '/terms-service' => ['priority' => 0.3, 'freq' => 'yearly'],
+            '/content-policy' => ['priority' => 0.3, 'freq' => 'yearly'],
+        ];
+
+        foreach ($staticPages as $page => $meta) {
             $sitemap->add(
                 Url::create(url($page))
+                    ->setChangeFrequency($meta['freq'])
+                    ->setPriority($meta['priority'])
             );
         }
 
-        // Subjects
+        // 2. Subjects
         Subject::orderBy('name')->get()->each(function ($subject) use ($sitemap) {
             $sitemap->add(
                 Url::create(url($subject->slug))
                     ->setLastModificationDate($subject->updated_at)
+                    ->setChangeFrequency('weekly')
+                    ->setPriority(0.9)
             );
         });
 
-        // Published blogs
+        // 3. Subject Nodes (Chapters, Sub-topics & Study Materials)
+        $allNodes = Node::with('subject:id,slug')
+            ->whereNotNull('subject_id')
+            ->get(['id', 'subject_id', 'parent_id', 'slug', 'updated_at']);
+
+        $nodesById = $allNodes->keyBy('id');
+
+        foreach ($allNodes as $node) {
+            if (! $node->subject || ! $node->slug) {
+                continue;
+            }
+
+            $slugs = [$node->slug];
+            $curr = $node;
+
+            while ($curr->parent_id && isset($nodesById[$curr->parent_id])) {
+                $curr = $nodesById[$curr->parent_id];
+                if ($curr->slug) {
+                    array_unshift($slugs, $curr->slug);
+                }
+            }
+
+            $nodePath = '/'.$node->subject->slug.'/'.implode('/', $slugs);
+
+            $sitemap->add(
+                Url::create(url($nodePath))
+                    ->setLastModificationDate($node->updated_at)
+                    ->setChangeFrequency('weekly')
+                    ->setPriority(0.8)
+            );
+        }
+
+        // 4. Published Blogs
         Blog::where('is_published', true)
             ->orderByDesc('updated_at')
-            ->get()
+            ->get(['slug', 'updated_at'])
             ->each(function ($blog) use ($sitemap) {
                 $sitemap->add(
                     Url::create(url("/blogs/{$blog->slug}"))
                         ->setLastModificationDate($blog->updated_at)
+                        ->setChangeFrequency('weekly')
+                        ->setPriority(0.8)
+                );
+            });
+
+        // 5. Active & Contributor User Profiles (Filtering out blank/inactive accounts)
+        User::whereNotNull('username')
+            ->where(function ($query) {
+                $query->whereHas('blogs', fn ($q) => $q->where('is_published', true))
+                    ->orWhereHas('roles')
+                    ->orWhereHas('resources')
+                    ->orWhere(function ($sub) {
+                        $sub->whereNotNull('about')
+                            ->whereNotNull('institution');
+                    });
+            })
+            ->select(['username', 'updated_at'])
+            ->orderByDesc('updated_at')
+            ->get()
+            ->each(function ($user) use ($sitemap) {
+                $sitemap->add(
+                    Url::create(url("/u/{$user->username}"))
+                        ->setLastModificationDate($user->updated_at)
+                        ->setChangeFrequency('weekly')
+                        ->setPriority(0.5)
                 );
             });
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,10 @@
 User-agent: *
-Disallow:
+Disallow: /admin/
+Disallow: /api/
+Disallow: /profile
+Disallow: /support/my-tickets
+Disallow: /auth/
+Disallow: /onboarding
+Disallow: /me
+
+Sitemap: https://hscstack.site/sitemap.xml

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -31,7 +31,50 @@
     $ogType = 'website';
     $ogUrl = url()->current();
 
-    if ($pageComponent === 'Blog/Show' && !empty($props['blog'])) {
+    $isNoIndex = str_starts_with(strtolower($pageComponent), 'admin') || in_array($pageComponent, [
+        'auth/Onboarding',
+        'Onboarding',
+        'Profile',
+        'SupportMyTickets',
+        'errors/404',
+        'errors/503',
+    ], true);
+
+    $jsonLdSchemas = [];
+
+    // Base Organization & WebSite Schemas for sitelinks
+    $jsonLdSchemas[] = [
+        '@type' => 'Organization',
+        '@id' => url('/') . '/#organization',
+        'name' => 'HSCStack',
+        'url' => url('/'),
+        'logo' => [
+            '@type' => 'ImageObject',
+            'url' => $defaultOgImage,
+        ],
+        'sameAs' => [
+            'https://www.facebook.com/hscstack',
+            'https://github.com/hscstack',
+        ],
+    ];
+
+    $jsonLdSchemas[] = [
+        '@type' => 'WebSite',
+        '@id' => url('/') . '/#website',
+        'url' => url('/'),
+        'name' => 'HSCStack',
+        'description' => 'Curated open learning platform for HSC & SSC students in Bangladesh',
+        'publisher' => [
+            '@id' => url('/') . '/#organization',
+        ],
+    ];
+
+    if ($pageComponent === 'Home' && request()->is('ssc')) {
+        $metaTitle = 'SSC Study Materials, Lecture Notes & Question Bank - ' . config('app.name', 'HSCStack');
+        $ogTitle = 'SSC Study Materials & Question Bank - HSCStack';
+        $metaDescription = 'Explore curated SSC video lectures, notes, books, and question banks for Science, Commerce, and Arts on HSCStack.';
+        $ogUrl = url('/ssc');
+    } elseif ($pageComponent === 'Blog/Show' && !empty($props['blog'])) {
         $blog = $props['blog'];
         $rawTitle = data_get($blog, 'meta_title') ?: data_get($blog, 'title');
         $metaTitle = $rawTitle ? "{$rawTitle} - " . config('app.name', 'HSCStack') : config('app.name', 'HSCStack');
@@ -40,6 +83,27 @@
         $ogImage = data_get($blog, 'featured_image') ?: $defaultOgImage;
         $ogType = 'article';
         $ogUrl = data_get($blog, 'slug') ? url('/blogs/' . data_get($blog, 'slug')) : url()->current();
+
+        $jsonLdSchemas[] = [
+            '@type' => 'BlogPosting',
+            'mainEntityOfPage' => [
+                '@type' => 'WebPage',
+                '@id' => $ogUrl,
+            ],
+            'headline' => $ogTitle,
+            'description' => $metaDescription,
+            'image' => $ogImage,
+            'datePublished' => data_get($blog, 'created_at'),
+            'dateModified' => data_get($blog, 'updated_at'),
+            'author' => [
+                '@type' => 'Person',
+                'name' => data_get($blog, 'user.name', 'HSCStack Contributor'),
+                'url' => data_get($blog, 'user.username') ? url('/u/' . data_get($blog, 'user.username')) : null,
+            ],
+            'publisher' => [
+                '@id' => url('/') . '/#organization',
+            ],
+        ];
     } elseif ($pageComponent === 'User/Show' && !empty($props['profileUser'])) {
         $profileUser = $props['profileUser'];
         $userName = data_get($profileUser, 'name');
@@ -57,6 +121,18 @@
         $ogImage = data_get($profileUser, 'image_url') ?: $defaultOgImage;
         $ogType = 'profile';
         $ogUrl = $userHandle ? url('/u/' . $userHandle) : url()->current();
+
+        $jsonLdSchemas[] = [
+            '@type' => 'ProfilePage',
+            'mainEntity' => [
+                '@type' => 'Person',
+                'name' => $userName,
+                'alternateName' => "@{$userHandle}",
+                'description' => $metaDescription,
+                'image' => $ogImage,
+                'url' => $ogUrl,
+            ],
+        ];
     } elseif ($pageComponent === 'Node' && (!empty($props['breadcrumb']) || !empty($props['subject']))) {
         $crumbs = $props['breadcrumb'] ?? [];
         $lastCrumb = is_array($crumbs) && count($crumbs) ? end($crumbs) : null;
@@ -64,6 +140,34 @@
         $metaTitle = "{$nodeTitle} - " . config('app.name', 'HSCStack');
         $ogTitle = "{$nodeTitle} - HSCStack";
         $metaDescription = "Study materials, chapter breakdown, and lecture notes for {$nodeTitle} - HSCStack.";
+
+        if (!empty($crumbs)) {
+            $breadcrumbElements = [];
+            $accumulatedPath = '/' . data_get($props['subject'], 'slug');
+            
+            $breadcrumbElements[] = [
+                '@type' => 'ListItem',
+                'position' => 1,
+                'name' => data_get($props['subject'], 'name'),
+                'item' => url($accumulatedPath),
+            ];
+
+            $position = 2;
+            foreach ($crumbs as $crumb) {
+                $accumulatedPath .= '/' . data_get($crumb, 'slug');
+                $breadcrumbElements[] = [
+                    '@type' => 'ListItem',
+                    'position' => $position++,
+                    'name' => data_get($crumb, 'name'),
+                    'item' => url($accumulatedPath),
+                ];
+            }
+
+            $jsonLdSchemas[] = [
+                '@type' => 'BreadcrumbList',
+                'itemListElement' => $breadcrumbElements,
+            ];
+        }
     } elseif ($pageComponent === 'Resource' && !empty($props['resource'])) {
         $res = $props['resource'];
         $resTitle = data_get($res, 'title', 'Resource');
@@ -123,8 +227,19 @@
         $metaTitle = 'Content & Copyright Policy - ' . config('app.name', 'HSCStack');
         $ogTitle = 'Content & Copyright Policy - HSCStack';
         $metaDescription = 'Content and Copyright Policy of HSCStack. Information on educational resource fair use and contributor content guidelines.';
+    } elseif ($pageComponent === 'auth/Login' || $pageComponent === 'Login') {
+        $metaTitle = 'Log In - ' . config('app.name', 'HSCStack');
+        $ogTitle = 'Log In to HSCStack';
+        $metaDescription = 'Log in to HSCStack with Google to access study resources, lecture notes, track learning progress, and connect with fellow students.';
+        $ogUrl = url('/login');
     }
 @endphp
+        @if ($isNoIndex)
+            <meta name="robots" content="noindex, nofollow">
+        @else
+            <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+        @endif
+        <link rel="canonical" href="{{ $ogUrl }}">
         <meta name="description" content="{{ $metaDescription }}">
         <meta property="og:title" content="{{ $ogTitle }}">
         <meta property="og:description" content="{{ $metaDescription }}">
@@ -137,6 +252,12 @@
         <meta name="twitter:description" content="{{ $metaDescription }}">
         <meta name="twitter:image" content="{{ $ogImage }}">
         @fonts
+
+        @if (!empty($jsonLdSchemas))
+            <script type="application/ld+json">
+                {!! json_encode(['@context' => 'https://schema.org', '@graph' => $jsonLdSchemas], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) !!}
+            </script>
+        @endif
 
         @vite(['resources/css/app.css', 'resources/js/app.ts', "resources/js/pages/{$page['component']}.vue"])
         <x-inertia::head>


### PR DESCRIPTION
## Summary of Changes

This PR delivers a comprehensive SEO overhaul to improve organic search visibility, eliminate crawl budget waste, and provide Google with structured data to enable rich snippets and Google Sitelinks.

### 1. Schema.org JSON-LD Structured Data (`resources/views/app.blade.php`)
- **`WebSite` & `Organization` Graph**: Brand identity, domain URLs, logo, and official social handles (Facebook, GitHub) to support Google Sitelinks and search visibility.
- **`BreadcrumbList`**: Automatically constructed for subject and chapter topic hierarchy (`/{subject}/{path...}`).
- **`BlogPosting`**: Complete article schema for published blogs including author, timestamps, headline, and featured images.
- **`ProfilePage`**: Structured Person schema for public user profiles (`/u/{username}`).

### 2. Canonical URLs & Robot Directives (`resources/views/app.blade.php`)
- Added `<link rel="canonical" href="...">` on all pages to resolve duplicate URL variations.
- Added smart `<meta name="robots">` directives:
  - `noindex, nofollow` on private/internal pages (`/admin/*`, `/onboarding`, `/profile`, `/support/my-tickets`, `404`, `503`).
  - `index, follow, max-image-preview:large` on public pages, including the `/login` landing page.
- Tailored meta titles and descriptions for `/ssc` and `/login`.

### 3. Robots.txt Configuration (`public/robots.txt`)
- Disallowed private/authenticated endpoints (`/admin/`, `/api/`, `/profile`, `/support/my-tickets`, `/auth/`, `/onboarding`, `/me`).
- Allowed `/login` for crawlability and sitelink eligibility.
- Linked `Sitemap: https://hscstack.site/sitemap.xml`.

### 4. Dynamic Sitemap Generation (`GenerateSitemap.php`)
- **Subject Node Traversal**: All chapter, sub-topic, and study material nodes are dynamically resolved into nested paths (`/{subject}/{path...}`) and indexed.
- **Active User Profiles**: Selectively includes active creators/contributors (authors, resource uploaders, bio/institution holders) while omitting blank accounts.
- **Static Pages**: Added missing `/projects`, `/ai`, `/support`, and `/login` with appropriate priorities.
- `.gitignore`: Added `/public/sitemap.xml` to avoid committing generated static sitemaps.