### PR TITLE
fix: use XSRF-TOKEN cookie for broadcast auth

### DIFF
--- a/resources/js/lib/echo.ts
+++ b/resources/js/lib/echo.ts
@@ -33,12 +33,14 @@ export function getEcho(key?: string, cluster?: string): Echo<'pusher'> | null {
         authEndpoint: '/broadcasting/auth',
         auth: {
             headers: {
-                'X-CSRF-TOKEN':
-                    (
-                        document.querySelector(
-                            'meta[name="csrf-token"]',
-                        ) as HTMLMetaElement
-                    )?.content || '',
+                'X-XSRF-TOKEN': decodeURIComponent(
+                    document.cookie
+                        .split('; ')
+                        .find((c) => c.startsWith('XSRF-TOKEN='))
+                        ?.split('=')
+                        .slice(1)
+                        .join('=') || '',
+                ),
                 'X-Requested-With': 'XMLHttpRequest',
             },
         },


### PR DESCRIPTION
The app has no `<meta name="csrf-token">` tag, so the Echo auth header `X-CSRF-TOKEN` was being sent empty → 403 on `/broadcasting/auth`.

Switches to reading the `XSRF-TOKEN` cookie (which Laravel always sets) and sending it as `X-XSRF-TOKEN` header instead.