### PR TITLE
feat: validate profanity on user profile fields and change chat_banne…

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Mail\WelcomeUserMail;
 use App\Models\User;
+use App\Rules\CleanText;
+use App\Services\ChatProfanityFilter;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
@@ -85,10 +87,13 @@ class AuthController extends Controller
             return redirect()->intended($defaultUrl);
         }
 
+        $rawName = $googleUser->getName() ?? $googleUser->getNickname() ?? '';
+        $cleanGoogleName = ChatProfanityFilter::hasProfanity($rawName) ? 'Student' : $rawName;
+
         $request->session()->put('onboarding_user', [
             'google_id' => $googleUser->getId(),
             'email' => $googleUser->getEmail(),
-            'name' => $googleUser->getName() ?? $googleUser->getNickname() ?? '',
+            'name' => $cleanGoogleName,
             'avatar' => $googleUser->getAvatar() ?? null,
         ]);
 
@@ -125,7 +130,7 @@ class AuthController extends Controller
         $onboardingData = $request->session()->get('onboarding_user');
 
         $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', new CleanText],
             'username' => [
                 'required',
                 'string',
@@ -133,8 +138,9 @@ class AuthController extends Controller
                 'max:30',
                 'regex:/^[a-zA-Z0-9_]+$/',
                 'unique:users,username',
+                new CleanText,
             ],
-            'school' => ['required', 'string', 'max:255'],
+            'school' => ['required', 'string', 'max:255', new CleanText],
             'image' => ['sometimes', 'nullable', 'image', 'max:5120'],
         ], [
             'school.required' => 'Please enter your school, college, or institution name.',

--- a/app/Http/Requests/Profile/UpdateProfileRequest.php
+++ b/app/Http/Requests/Profile/UpdateProfileRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Profile;
 
+use App\Rules\CleanText;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -24,7 +25,7 @@ class UpdateProfileRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', new CleanText],
             'username' => [
                 'sometimes',
                 'string',
@@ -32,10 +33,11 @@ class UpdateProfileRequest extends FormRequest
                 'max:30',
                 'regex:/^[a-zA-Z0-9_]+$/',
                 Rule::unique('users', 'username')->ignore($this->user()->id),
+                new CleanText,
             ],
             'file' => ['sometimes', 'nullable', 'image', 'max:2048'],
-            'about' => ['sometimes', 'nullable', 'string'],
-            'institution' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'about' => ['sometimes', 'nullable', 'string', 'max:1000', new CleanText],
+            'institution' => ['sometimes', 'nullable', 'string', 'max:255', new CleanText],
             'facebook' => ['sometimes', 'nullable', 'string', 'max:255'],
             'instagram' => ['sometimes', 'nullable', 'string', 'max:255'],
             'github' => ['sometimes', 'nullable', 'string', 'max:255'],

--- a/app/Http/Requests/User/StoreUserRequest.php
+++ b/app/Http/Requests/User/StoreUserRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\User;
 
+use App\Rules\CleanText;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -24,16 +25,16 @@ class StoreUserRequest extends FormRequest
     {
         return [
 
-            'name' => ['required', 'string', 'max:255'],
-            'username' => ['nullable', 'string', 'min:3', 'max:30', 'regex:/^[a-zA-Z0-9_]+$/', 'unique:users,username'],
+            'name' => ['required', 'string', 'max:255', new CleanText],
+            'username' => ['nullable', 'string', 'min:3', 'max:30', 'regex:/^[a-zA-Z0-9_]+$/', 'unique:users,username', new CleanText],
             'email' => ['required', 'email', 'unique:users,email'],
             'role' => ['nullable', 'string'],
             'permissions' => ['nullable', 'array'],
             'permissions.*' => ['string', 'exists:permissions,name'],
             'file' => ['nullable', 'image', 'max:2048'],
-            'about' => ['nullable', 'string'],
-            'title' => ['nullable', 'string'],
-            'institution' => ['nullable', 'string', 'max:255'],
+            'about' => ['nullable', 'string', 'max:1000', new CleanText],
+            'title' => ['nullable', 'string', 'max:255', new CleanText],
+            'institution' => ['nullable', 'string', 'max:255', new CleanText],
             'facebook' => ['nullable', 'string', 'max:255'],
             'instagram' => ['nullable', 'string', 'max:255'],
             'github' => ['nullable', 'string', 'max:255'],

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\User;
 
+use App\Rules\CleanText;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -25,7 +26,7 @@ class UpdateUserRequest extends FormRequest
         $user = $this->route('user');
 
         $rules = [
-            'name' => ['sometimes', 'string', 'max:255'],
+            'name' => ['sometimes', 'string', 'max:255', new CleanText],
             'username' => [
                 'sometimes',
                 'nullable',
@@ -34,12 +35,13 @@ class UpdateUserRequest extends FormRequest
                 'max:30',
                 'regex:/^[a-zA-Z0-9_]+$/',
                 'unique:users,username,'.$user->id,
+                new CleanText,
             ],
             'email' => ['sometimes', 'email', 'unique:users,email,'.$user->id],
             'file' => ['sometimes', 'nullable', 'image', 'max:2048'],
-            'about' => ['sometimes', 'nullable', 'string'],
-            'title' => ['sometimes', 'nullable', 'string'],
-            'institution' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'about' => ['sometimes', 'nullable', 'string', 'max:1000', new CleanText],
+            'title' => ['sometimes', 'nullable', 'string', 'max:255', new CleanText],
+            'institution' => ['sometimes', 'nullable', 'string', 'max:255', new CleanText],
             'facebook' => ['sometimes', 'nullable', 'string', 'max:255'],
             'instagram' => ['sometimes', 'nullable', 'string', 'max:255'],
             'github' => ['sometimes', 'nullable', 'string', 'max:255'],

--- a/app/Rules/CleanText.php
+++ b/app/Rules/CleanText.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Rules;
+
+use App\Services\ChatProfanityFilter;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class CleanText implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (is_string($value) && trim($value) !== '' && ChatProfanityFilter::hasProfanity($value)) {
+            $attributeName = str_replace('_', ' ', $attribute);
+            $fail("The {$attributeName} contains inappropriate or prohibited language.");
+        }
+    }
+}

--- a/database/migrations/2026_08_30_172418_change_chat_banned_until_to_datetime_in_users_table.php
+++ b/database/migrations/2026_08_30_172418_change_chat_banned_until_to_datetime_in_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dateTime('chat_banned_until')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('chat_banned_until')->nullable()->change();
+        });
+    }
+};

--- a/tests/Feature/UserProfileTest.php
+++ b/tests/Feature/UserProfileTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\AppSetting;
 use App\Models\Blog;
 use App\Models\Node;
 use App\Models\NodeVote;
@@ -206,4 +207,34 @@ test('public profile returns created folders in recent activities', function () 
         ->where('recentActivities.folders.0.subtitle', 'Physics')
         ->where('recentActivities.folders.0.url', '/physics/thermodynamics-chapter')
     );
+});
+
+test('profile update rejects inappropriate words in name, username, about, or institution', function () {
+    AppSetting::set('global_chat_banned_words', 'badword, offensive');
+
+    $user = User::factory()->create(['username' => 'clean_user']);
+
+    $response = $this->actingAs($user)->put('/profile', [
+        'name' => 'Badword Person',
+        'username' => 'clean_user',
+    ]);
+    $response->assertSessionHasErrors(['name']);
+
+    $response = $this->actingAs($user)->put('/profile', [
+        'name' => 'John Doe',
+        'username' => 'offensive_user',
+    ]);
+    $response->assertSessionHasErrors(['username']);
+
+    $response = $this->actingAs($user)->put('/profile', [
+        'name' => 'John Doe',
+        'about' => 'This is badword content',
+    ]);
+    $response->assertSessionHasErrors(['about']);
+
+    $response = $this->actingAs($user)->put('/profile', [
+        'name' => 'John Doe',
+        'institution' => 'Offensive College',
+    ]);
+    $response->assertSessionHasErrors(['institution']);
 });


### PR DESCRIPTION
…d_until to datetime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added profanity screening to Google onboarding and profile fields.
  - Automatically replaces profane Google profile names with “Student.”
  - Added length limits for profile descriptions and titles.
  - Improved precision for chat-ban expiration times.

- **Bug Fixes**
  - Prevents disallowed text from being submitted through profile and user forms.

- **Tests**
  - Added coverage verifying profanity validation across profile fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->