### PR TITLE
Fix/forum comment deletion and welcome url

### DIFF
--- a/app/Notifications/WelcomeNotification.php
+++ b/app/Notifications/WelcomeNotification.php
@@ -34,7 +34,7 @@ class WelcomeNotification extends Notification implements ShouldQueue
                     'You can explore curated study notes, syllabus trees, participate in the community forum, and read blogs.',
                 ],
                 'actionText' => 'Get Started',
-                'actionUrl' => route('index'),
+                'actionUrl' => route('me'),
             ]);
     }
 
@@ -44,7 +44,7 @@ class WelcomeNotification extends Notification implements ShouldQueue
             'type' => 'welcome',
             'title' => 'Welcome to HSCStack! 🎓',
             'message' => 'Your account is ready. Explore notes, syllabus, and discussions.',
-            'url' => route('index'),
+            'url' => route('me'),
         ];
     }
 }

--- a/resources/js/pages/Forum/Show.vue
+++ b/resources/js/pages/Forum/Show.vue
@@ -1117,7 +1117,10 @@ function parseMentions(
 
                     <!-- Delete button for direct answer -->
                     <button
-                        v-if="user && user.id === answer.user_id"
+                        v-if="
+                            user &&
+                            (user.id === answer.user_id || can('manage forums'))
+                        "
                         type="button"
                         @click="deleteAnswer(answer.id)"
                         class="rounded-lg p-1 text-slate-400 transition hover:bg-rose-50 hover:text-rose-600 dark:text-gray-500 dark:hover:bg-rose-950/30 dark:hover:text-rose-400"
@@ -1279,7 +1282,11 @@ function parseMentions(
 
                             <!-- Delete reply -->
                             <button
-                                v-if="user && user.id === reply.user_id"
+                                v-if="
+                                    user &&
+                                    (user.id === reply.user_id ||
+                                        can('manage forums'))
+                                "
                                 type="button"
                                 @click="deleteAnswer(reply.id)"
                                 class="rounded p-1 text-slate-400 hover:bg-rose-50 hover:text-rose-600 dark:text-gray-500 dark:hover:bg-rose-950/30 dark:hover:text-rose-400"

--- a/tests/Feature/AdminForumTest.php
+++ b/tests/Feature/AdminForumTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\AppSetting;
 use App\Models\ChatMessage;
+use App\Models\ForumAnswer;
 use App\Models\ForumPost;
 use App\Models\Report;
 use App\Models\User;
@@ -323,4 +324,42 @@ test('user without manage chat or manage forums permission cannot suspend a user
         ->assertSessionHas('error');
 
     expect($targetUser->fresh()->isBanned())->toBeFalse();
+});
+
+test('admin with manage forums permission can delete any forum answer', function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('admin');
+
+    $author = User::factory()->create();
+    $post = ForumPost::factory()->create(['user_id' => $author->id]);
+    $answer = ForumAnswer::create([
+        'forum_post_id' => $post->id,
+        'user_id' => $author->id,
+        'body' => 'Answer to be deleted by admin',
+    ]);
+    $post->update(['answers_count' => 1]);
+
+    $this->actingAs($admin)
+        ->delete(route('forum.answers.destroy', $answer))
+        ->assertRedirect();
+
+    expect(ForumAnswer::find($answer->id))->toBeNull();
+    expect($post->fresh()->answers_count)->toBe(0);
+});
+
+test('regular user cannot delete another users forum answer', function () {
+    $regularUser = User::factory()->create();
+    $author = User::factory()->create();
+    $post = ForumPost::factory()->create(['user_id' => $author->id]);
+    $answer = ForumAnswer::create([
+        'forum_post_id' => $post->id,
+        'user_id' => $author->id,
+        'body' => 'Answer that should not be deleted by stranger',
+    ]);
+
+    $this->actingAs($regularUser)
+        ->delete(route('forum.answers.destroy', $answer))
+        ->assertForbidden();
+
+    expect(ForumAnswer::find($answer->id))->not->toBeNull();
 });

--- a/tests/Feature/WelcomeNotificationTest.php
+++ b/tests/Feature/WelcomeNotificationTest.php
@@ -24,7 +24,7 @@ test('welcome notification delivers to both database and mail when user accepts 
     $dbData = $notification->toArray($user);
     expect($dbData['type'])->toBe('welcome')
         ->and($dbData['title'])->toBe('Welcome to HSCStack! 🎓')
-        ->and($dbData['url'])->toBe(route('index'));
+        ->and($dbData['url'])->toBe(route('me'));
 
     $mailMessage = $notification->toMail($user);
     expect($mailMessage->subject)->toBe('Welcome to HSCStack! 🎓');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forum managers can now delete answers and replies, in addition to their authors.
  * Welcome notifications now link directly to the authenticated user’s page.

* **Bug Fixes**
  * Corrected notification links so database and email notifications direct recipients to the appropriate destination.

* **Tests**
  * Added coverage confirming authorized forum deletion behavior and notification link accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->