### PR TITLE
fix(css): prevent unthemed background bleed on overscroll + auto-format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log
 /.idea
 /.nova
 /.vscode
+!/.vscode/settings.json
 /.zed
 /prompt
 storage/debugbar/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
+#!/bin/sh
 npx lint-staged
-

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,34 @@
+{
+  // Tailwind CSS v4: silence VS Code's built-in CSS validator for Tailwind at-rules (@source, @theme, @custom-variant, @apply)
+  "css.lint.unknownAtRules": "ignore",
+  "scss.lint.unknownAtRules": "ignore",
+  // Tailwind IntelliSense — enable completions inside strings (e.g. class="...")
+  "editor.quickSuggestions": {
+    "strings": true
+  },
+  // Ensure Tailwind CSS extension treats app.css as Tailwind
+  "files.associations": {
+    "*.css": "tailwindcss"
+  },
+  // Auto-format on save (Prettier + ESLint)
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
     "types:check": "vue-tsc --noEmit",
     "prepare": "husky"
   },
+  "lint-staged": {
+    "resources/**/*.{js,ts,vue,css}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
+  },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "@laravel/vite-plugin-wayfinder": "^0.1.3",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -34,7 +34,7 @@
     html,
     body {
         font-stretch: 96%;
-        @apply transition-colors duration-300;
+        @apply bg-slate-50 transition-colors duration-300 dark:bg-gray-950;
         scrollbar-width: none; /* Firefox */
         -ms-overflow-style: none; /* IE and Edge */
     }


### PR DESCRIPTION
Summary: Fix overscroll grey leak by setting html,body bg to bg-slate-50 dark:bg-gray-950 in resources/css/app.css:34.
Before:
<img width="1919" height="1040" alt="Screenshot 2026-09-01 130822" src="https://github.com/user-attachments/assets/a6283087-5100-4b82-8349-083f6ef0c87b" />
After:
<img width="1919" height="1038" alt="Screenshot 2026-09-01 132522" src="https://github.com/user-attachments/assets/156e692a-11ad-4157-8b31-d04b4d5e7139" />
