### PR TITLE
fix(forum): prevent horizontal overflow in question and answer action bars

### DIFF
--- a/resources/js/pages/Forum/Show.vue
+++ b/resources/js/pages/Forum/Show.vue
@@ -791,7 +791,7 @@ function parseMentions(
             <div
                 class="mt-3 flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 pb-4 text-xs text-slate-400 dark:border-gray-800 dark:text-gray-500"
             >
-                <div class="flex items-center gap-2">
+                <div class="flex flex-wrap items-center gap-2">
                     <Link
                         v-if="post.user?.username"
                         :href="`/u/${post.user.username}`"
@@ -948,7 +948,7 @@ function parseMentions(
                 </div>
 
                 <!-- Right: Moderator and Owner Actions -->
-                <div class="flex items-center gap-2">
+                <div class="flex flex-wrap items-center gap-2">
                     <!-- Inline Moderator Tools -->
                     <template v-if="can('manage forums') || can('manage chat')">
                         <!-- Suspend Author Button -->
@@ -1166,7 +1166,7 @@ function parseMentions(
 
                 <!-- Direct Answer Action Row -->
                 <div
-                    class="mt-3 flex items-center justify-between border-t border-slate-100 pt-2.5 dark:border-gray-800/80"
+                    class="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-slate-100 pt-2.5 dark:border-gray-800/80"
                 >
                     <ForumVoteButtons
                         votableType="answer"
@@ -1178,7 +1178,7 @@ function parseMentions(
                         size="sm"
                     />
 
-                    <div class="flex items-center gap-1">
+                    <div class="flex flex-wrap items-center gap-1">
                         <!-- Moderator Suspend Author Button -->
                         <button
                             v-if="
@@ -1334,7 +1334,7 @@ function parseMentions(
 
                         <!-- Reply Actions -->
                         <div
-                            class="mt-2 flex items-center justify-between border-t border-slate-200/50 pt-1.5 dark:border-gray-700/50"
+                            class="mt-2 flex flex-wrap items-center justify-between gap-2 border-t border-slate-200/50 pt-1.5 dark:border-gray-700/50"
                         >
                             <ForumVoteButtons
                                 votableType="answer"
@@ -1346,7 +1346,7 @@ function parseMentions(
                                 size="sm"
                             />
 
-                            <div class="flex items-center gap-1">
+                            <div class="flex flex-wrap items-center gap-1">
                                 <!-- Moderator Suspend Author Button -->
                                 <button
                                     v-if="


### PR DESCRIPTION
### Summary of Changes

- **Question Author Meta Row**: Added `flex-wrap` to ensure long usernames/institutions wrap cleanly on smaller mobile viewports.
- **Question Moderator & Owner Action Bar**: Added `flex-wrap` to container holding moderation tools (`Suspend`, `Lock`, `Moderation Status Select`, `Report`, `Delete`) preventing viewport width expansion and cut-off on mobile devices.
- **Direct Answers & Reply Action Bars**: Added `flex-wrap` and `gap-2` to ensure voting buttons and reply/moderator actions stack responsively without pushing viewport width.

### Verification
- Tested with Prettier, ESLint, Pint (`npm run format:check`, `npm run lint:check`, `composer lint:check`).
- Passed 57/57 Pest tests for Forum feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forum page responsiveness on narrow screens.
  * Buttons, author details, and action controls now wrap cleanly instead of overflowing.
  * Added spacing between wrapped elements for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->