### PR TITLE
fix(pwa): add 192x192 and maskable purpose to manifest icons

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,8 +49,21 @@ export default defineConfig({
                 icons: [
                     {
                         src: '/favicon.png',
+                        sizes: '192x192',
+                        type: 'image/png',
+                        purpose: 'any',
+                    },
+                    {
+                        src: '/favicon.png',
                         sizes: '512x512',
                         type: 'image/png',
+                        purpose: 'any',
+                    },
+                    {
+                        src: '/favicon.png',
+                        sizes: '512x512',
+                        type: 'image/png',
+                        purpose: 'maskable',
                     },
                 ],
             },


### PR DESCRIPTION
Closes #125 — adds 192 and maskable to vite.config.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved progressive web app icon support across standard and maskable display modes.
  * Added a 192×192 icon for better compatibility with supported devices and installation experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->