### PR TITLE
feat(pwa): show PWA install prompt modal in Forum pages

### DIFF
--- a/resources/js/pages/Forum/Index.vue
+++ b/resources/js/pages/Forum/Index.vue
@@ -15,6 +15,7 @@ import {
 import { computed, ref, watch } from 'vue';
 import AuthModal from '@/components/AuthModal.vue';
 import ForumVoteButtons from '@/components/forum/ForumVoteButtons.vue';
+import PwaInstallPrompt from '@/components/PwaInstallPrompt.vue';
 
 interface User {
     id: number;
@@ -1169,5 +1170,8 @@ function timeAgo(dateString?: string): string {
             title="Sign in required"
             message="Please sign in to ask a question in the forum."
         />
+
+        <!-- PWA Install Prompt Modal -->
+        <PwaInstallPrompt variant="modal" />
     </main>
 </template>

--- a/resources/js/pages/Forum/Show.vue
+++ b/resources/js/pages/Forum/Show.vue
@@ -28,7 +28,6 @@ import ChatBanModal from '@/components/ChatBanModal.vue';
 import type { ChatBanUser } from '@/components/ChatBanModal.vue';
 import ForumVoteButtons from '@/components/forum/ForumVoteButtons.vue';
 import ImageViewerModal from '@/components/ImageViewerModal.vue';
-import PwaInstallPrompt from '@/components/PwaInstallPrompt.vue';
 import UserListItem from '@/components/UserListItem.vue';
 import { usePermissions } from '@/lib/usePermissions';
 

--- a/resources/js/pages/Forum/Show.vue
+++ b/resources/js/pages/Forum/Show.vue
@@ -1937,8 +1937,5 @@ function parseMentions(
             :user="selectedBanUser"
             @close="isBanModalOpen = false"
         />
-
-        <!-- PWA Install Prompt Modal -->
-        <PwaInstallPrompt variant="modal" />
     </main>
 </template>

--- a/resources/js/pages/Forum/Show.vue
+++ b/resources/js/pages/Forum/Show.vue
@@ -28,6 +28,7 @@ import ChatBanModal from '@/components/ChatBanModal.vue';
 import type { ChatBanUser } from '@/components/ChatBanModal.vue';
 import ForumVoteButtons from '@/components/forum/ForumVoteButtons.vue';
 import ImageViewerModal from '@/components/ImageViewerModal.vue';
+import PwaInstallPrompt from '@/components/PwaInstallPrompt.vue';
 import UserListItem from '@/components/UserListItem.vue';
 import { usePermissions } from '@/lib/usePermissions';
 
@@ -1936,5 +1937,8 @@ function parseMentions(
             :user="selectedBanUser"
             @close="isBanModalOpen = false"
         />
+
+        <!-- PWA Install Prompt Modal -->
+        <PwaInstallPrompt variant="modal" />
     </main>
 </template>


### PR DESCRIPTION
### Summary of Changes
- Included `<PwaInstallPrompt variant="modal" />` in:
  - `resources/js/pages/Forum/Index.vue`
  - `resources/js/pages/Forum/Show.vue`
- Matches the install prompt experience already present on `Home.vue` and `Chat/Index.vue` (automatically respects session dismissal and only prompts when PWA installation is available and uninstalled).