### PR TITLE
feat(auth): forward current page URL as redirect on navbar and guest login clicks

### DIFF
--- a/resources/js/components/NavBar.vue
+++ b/resources/js/components/NavBar.vue
@@ -81,6 +81,21 @@ const isHomeOrSsc = computed(
         currentUrl.value.startsWith('/ssc?'),
 );
 
+const loginUrl = computed(() => {
+    const path = currentUrl.value;
+
+    if (
+        !path ||
+        path === '/' ||
+        path.startsWith('/login') ||
+        path.startsWith('/auth/')
+    ) {
+        return '/login';
+    }
+
+    return `/login?redirect=${encodeURIComponent(path)}`;
+});
+
 const showAuthModal = ref(false);
 const authModalMessage = ref('অনুগ্রহ করে সার্চ ফিচার ব্যবহার করতে লগইন করুন।');
 const showLogoutModal = ref(false);
@@ -387,7 +402,7 @@ onBeforeUnmount(() => {
                     <!-- Guest: Login CTA -->
                     <Link
                         v-if="!user"
-                        href="/login"
+                        :href="loginUrl"
                         class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-xs font-bold text-white shadow-xs transition-all hover:bg-slate-800 hover:shadow-md active:scale-95 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
                     >
                         <LogIn class="h-3.5 w-3.5" />
@@ -534,7 +549,7 @@ onBeforeUnmount(() => {
                     <!-- Compact Mobile Login Button (if guest) -->
                     <Link
                         v-if="!user"
-                        href="/login"
+                        :href="loginUrl"
                         class="inline-flex items-center gap-1.5 rounded-xl bg-slate-900 px-3 py-2 text-xs font-bold text-white shadow-xs dark:bg-gray-100 dark:text-gray-900"
                     >
                         <LogIn class="h-3.5 w-3.5" />
@@ -671,7 +686,7 @@ onBeforeUnmount(() => {
 
                             <div v-else>
                                 <Link
-                                    href="/login"
+                                    :href="loginUrl"
                                     @click="closeMobileMenu"
                                     class="flex w-full items-center justify-center gap-2 rounded-2xl bg-indigo-600 px-4 py-2.5 text-xs font-bold text-white shadow-md shadow-indigo-600/20 transition-all hover:bg-indigo-500 active:scale-98"
                                 >

--- a/resources/js/pages/Chat/Index.vue
+++ b/resources/js/pages/Chat/Index.vue
@@ -2230,7 +2230,7 @@ onUnmounted(() => {
 
                     <Link
                         v-if="!currentUser"
-                        href="/login"
+                        :href="`/login?redirect=${encodeURIComponent($page.url || '/chat')}`"
                         class="inline-flex items-center gap-1 font-semibold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
                     >
                         <LogIn class="h-3.5 w-3.5" />

--- a/resources/js/pages/User/Show.vue
+++ b/resources/js/pages/User/Show.vue
@@ -1646,7 +1646,7 @@ function timeAgo(dateString?: string): string {
                         Cancel
                     </button>
                     <Link
-                        href="/login"
+                        :href="`/login?redirect=${encodeURIComponent($page.url)}`"
                         class="inline-flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-slate-900 py-2.5 text-xs font-bold text-white shadow-xs transition hover:bg-slate-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
                     >
                         <LogIn class="h-3.5 w-3.5" />


### PR DESCRIPTION
### Summary of Changes
- In `NavBar.vue`, added a `loginUrl` computed property that forwards the current page URL as `?redirect=...` (excluding `/`, `/login`, and `/auth/*` paths).
- Updated Desktop login button, Mobile top header login button, and Mobile drawer login button to use `:href="loginUrl"`.
- Also updated guest sign-in buttons in `Chat/Index.vue` and `User/Show.vue` to preserve their respective return URLs on sign-in.
- Users signing in will now automatically return to the exact page they were browsing upon completing Google login.