### PR TITLE
feat(resource): add curriculum and subject context to resource page and SEO metadata

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -12,7 +12,7 @@ class ResourceController extends Controller
     public function show($id)
     {
         $data = Cache::rememberForever("resource_{$id}", function () use ($id) {
-            $resource = Resource::with('user')->findOrFail($id);
+            $resource = Resource::with(['user', 'node.subject'])->findOrFail($id);
 
             $previousResourceId = Resource::where('node_id', $resource->node_id)
                 ->where('id', '<', $resource->id)
@@ -26,6 +26,7 @@ class ResourceController extends Controller
 
             return [
                 'resource' => $resource->toArray(),
+                'subject' => $resource->node?->subject,
                 'previousResourceId' => $previousResourceId,
                 'nextResourceId' => $nextResourceId,
             ];

--- a/resources/js/pages/Resource.vue
+++ b/resources/js/pages/Resource.vue
@@ -23,6 +23,10 @@ const props = defineProps({
         type: Object,
         required: true,
     },
+    subject: {
+        type: Object,
+        default: null,
+    },
     previousResourceId: {
         type: Number,
         default: null,
@@ -180,15 +184,25 @@ const toggleFullscreen = () => {
 
 <template>
     <Head>
-        <title>{{ resource.title }}</title>
+        <title>
+            {{ resource.title
+            }}{{
+                subject
+                    ? ` - ${subject.course.toUpperCase()} - ${subject.name}`
+                    : ''
+            }}
+        </title>
         <meta
             name="description"
-            :content="`Study material: ${resource.title} (${resource.type}) on HSCStack - Open Learning Platform.`"
+            :content="`Study material: ${resource.title} (${resource.resource_type})${subject ? ` for ${subject.course.toUpperCase()} - ${subject.name}` : ''} on HSCStack.`"
         />
-        <meta property="og:title" :content="`${resource.title} - HSCStack`" />
+        <meta
+            property="og:title"
+            :content="`${resource.title}${subject ? ` - ${subject.course.toUpperCase()} - ${subject.name}` : ''} - HSCStack`"
+        />
         <meta
             property="og:description"
-            :content="`Study material: ${resource.title} (${resource.type}) on HSCStack.`"
+            :content="`Study material: ${resource.title} (${resource.resource_type})${subject ? ` for ${subject.course.toUpperCase()} - ${subject.name}` : ''} on HSCStack.`"
         />
     </Head>
 
@@ -211,12 +225,20 @@ const toggleFullscreen = () => {
                     />
                 </button>
 
-                <h1
-                    class="truncate text-sm font-bold text-slate-900 sm:text-base dark:text-gray-100"
-                    :title="resource.title"
-                >
-                    {{ resource.title }}
-                </h1>
+                <div class="min-w-0">
+                    <span
+                        v-if="subject"
+                        class="block truncate text-xs font-semibold text-indigo-600 dark:text-indigo-400"
+                    >
+                        {{ subject.course.toUpperCase() }} - {{ subject.name }}
+                    </span>
+                    <h1
+                        class="truncate text-sm font-bold text-slate-900 sm:text-base dark:text-gray-100"
+                        :title="resource.title"
+                    >
+                        {{ resource.title }}
+                    </h1>
+                </div>
             </div>
 
             <!-- Right: Action Buttons -->

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -189,11 +189,31 @@
         $res = $props['resource'];
         $resTitle = data_get($res, 'title', 'Resource');
         $resType = data_get($res, 'resource_type', 'material');
-        $metaTitle = "{$resTitle} - " . config('app.name', 'HSCStack');
-        $ogTitle = "{$resTitle} - HSCStack";
-        $metaDescription = "Study material: {$resTitle} ({$resType}) on HSCStack.";
-        if ($resType === 'image' && data_get($res, 'file_path')) {
-            $ogImage = str_starts_with(data_get($res, 'file_path'), 'http') ? data_get($res, 'file_path') : \Illuminate\Support\Facades\Storage::url(data_get($res, 'file_path'));
+        $subjectName = data_get($props, 'subject.name') ?: data_get($res, 'node.subject.name');
+        $subjectCourse = data_get($props, 'subject.course') ?: data_get($res, 'node.subject.course');
+        $subjectDisplay = $subjectName ? strtoupper($subjectCourse) . ' - ' . $subjectName : null;
+
+        $metaTitle = $subjectDisplay
+            ? "{$resTitle} - {$subjectDisplay} - " . config('app.name', 'HSCStack')
+            : "{$resTitle} - " . config('app.name', 'HSCStack');
+        $ogTitle = $subjectDisplay
+            ? "{$resTitle} - {$subjectDisplay} - " . config('app.name', 'HSCStack')
+            : "{$resTitle} - HSCStack";
+
+        $metaDescription = $subjectDisplay
+            ? "Study material: {$resTitle} ({$resType}) for {$subjectDisplay} on HSCStack."
+            : "Study material: {$resTitle} ({$resType}) on HSCStack.";
+
+        $filePath = data_get($res, 'file_path') ?: data_get($res, 'file_url');
+        $externalUrl = data_get($res, 'external_url') ?: data_get($res, 'file_url');
+
+        if ($resType === 'video' && $externalUrl) {
+            if (preg_match('/(?:youtube\.com\/(?:watch\?v=|embed\/|shorts\/)|youtu\.be\/)([a-zA-Z0-9_-]+)/', $externalUrl, $matches)) {
+                $ogImage = "https://img.youtube.com/vi/{$matches[1]}/hqdefault.jpg";
+            }
+            $ogType = 'video.other';
+        } elseif ($resType === 'image' && $filePath) {
+            $ogImage = str_starts_with($filePath, 'http') ? $filePath : \Illuminate\Support\Facades\Storage::url($filePath);
         }
     } elseif ($pageComponent === 'Blog/Index') {
         $metaTitle = 'Educational Blogs & Study Guides - ' . config('app.name', 'HSCStack');

--- a/tests/Feature/AdminForumTest.php
+++ b/tests/Feature/AdminForumTest.php
@@ -105,7 +105,7 @@ test('unpublished post is not visible on public forum index and returns 404 for 
 
     // Show endpoint returns 404 for regular non-author user on rejected post
     $hiddenResponse = $this->actingAs($user)->get(route('forum.show', $hiddenPost));
-    $hiddenResponse->assertSee('errors\/404');
+    $hiddenResponse->assertInertia(fn ($page) => $page->component('errors/404'));
     $this->actingAs($user)->get(route('forum.show', $publishedPost))->assertStatus(200);
 });
 

--- a/tests/Feature/ForumTest.php
+++ b/tests/Feature/ForumTest.php
@@ -546,11 +546,11 @@ test('author and admin can view pending or flagged questions but other users get
     $this->actingAs($admin)->get(route('forum.show', $flaggedPost))->assertStatus(200);
 
     // Other user gets 404
-    $this->actingAs($otherUser)->get(route('forum.show', $pendingPost))->assertSee('errors\/404');
-    $this->actingAs($otherUser)->get(route('forum.show', $flaggedPost))->assertSee('errors\/404');
+    $this->actingAs($otherUser)->get(route('forum.show', $pendingPost))->assertInertia(fn ($page) => $page->component('errors/404'));
+    $this->actingAs($otherUser)->get(route('forum.show', $flaggedPost))->assertInertia(fn ($page) => $page->component('errors/404'));
 
     // Guest gets 404
-    $this->get(route('forum.show', $pendingPost))->assertSee('errors\/404');
+    $this->get(route('forum.show', $pendingPost))->assertInertia(fn ($page) => $page->component('errors/404'));
 });
 
 test('suspended user cannot access ask question page', function () {

--- a/tests/Feature/PublicPagesTest.php
+++ b/tests/Feature/PublicPagesTest.php
@@ -1,9 +1,12 @@
 <?php
 
 use App\Models\Blog;
+use App\Models\Node;
 use App\Models\Notice;
+use App\Models\Subject;
 use App\Models\User;
 use Illuminate\Support\Facades\Cache;
+use Inertia\Testing\AssertableInertia;
 
 test('the homepage loads successfully', function () {
     $response = $this->get('/');
@@ -61,5 +64,42 @@ test('non-existent public resources render the 404 error page', function () {
     $response = $this->get('/resources/999999');
 
     $response->assertStatus(404);
-    $response->assertSee('errors\/404');
+    $response->assertInertia(fn (AssertableInertia $page) => $page->component('errors/404'));
+});
+
+test('public resource page loads with subject, node, and enriched SEO metadata', function () {
+    $subject = Subject::create([
+        'name' => 'Higher Mathematics',
+        'slug' => 'higher-math',
+        'course' => 'hsc',
+        'tailwind_format' => 'bg-indigo-500',
+        'icon' => 'calculator',
+    ]);
+
+    $node = Node::create([
+        'subject_id' => $subject->id,
+        'name' => 'Matrix and Determinants',
+        'slug' => 'matrix-and-determinants',
+    ]);
+
+    $resource = App\Models\Resource::create([
+        'node_id' => $node->id,
+        'resource_type' => 'video',
+        'title' => 'Matrix o nirnayok 01',
+        'external_url' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    ]);
+
+    $response = $this->get("/resources/{$resource->id}");
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Resource')
+        ->where('resource.id', $resource->id)
+        ->where('subject.name', 'Higher Mathematics')
+        ->where('subject.course', 'hsc')
+    );
+
+    $appName = config('app.name', 'HSCStack');
+    $response->assertSee("Matrix o nirnayok 01 - HSC - Higher Mathematics - {$appName}", false);
+    $response->assertSee('Study material: Matrix o nirnayok 01 (video) for HSC - Higher Mathematics on HSCStack.', false);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource pages now display associated subject and course information alongside the resource title.
  * Resource SEO metadata includes subject and course details when available.
  * Video resources with external URLs now use YouTube thumbnails and video-specific Open Graph metadata.

* **Bug Fixes**
  * Improved handling of resource types in meta descriptions.

* **Tests**
  * Enhanced coverage for resource details, SEO metadata, and Inertia-based 404 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->