### PR TITLE
fix(auth): close logout confirm when logging out

### DIFF
--- a/resources/js/components/LogoutConfirmModal.vue
+++ b/resources/js/components/LogoutConfirmModal.vue
@@ -143,6 +143,7 @@ onBeforeUnmount(() => {
                         href="/logout"
                         method="post"
                         as="button"
+                        @click="close"
                         class="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-rose-600 py-2.5 text-xs font-bold text-white shadow-sm transition hover:bg-rose-700 active:scale-95 dark:bg-rose-600 dark:hover:bg-rose-500"
                     >
                         <MaterialIcon name="logout" :size="16" />


### PR DESCRIPTION
Modal stayed open after confirming because persistent layouts keep component state across the post-logout redirect. Close on confirm click; the POST proceeds normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The logout confirmation modal now closes when logout is initiated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->