### PR TITLE
feat(nav): replace AI with Blogs in default mobile bottom nav

### DIFF
--- a/resources/js/lib/useBottomNavCustomization.ts
+++ b/resources/js/lib/useBottomNavCustomization.ts
@@ -14,7 +14,7 @@ const CUSTOMIZABLE_POOL: NavItem[] = allNavItems.filter(
     (i) => i.href !== HOME_HREF,
 );
 
-const DEFAULT_MIDDLE_HREFS = ['/forum', '/chat', '/ai']; // 3 middle → 5 total with Home+Account
+const DEFAULT_MIDDLE_HREFS = ['/forum', '/chat', '/blogs']; // 3 middle → 5 total with Home+Account
 
 type BottomNavUser = {
     name: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The default middle navigation bar now links to **Blogs** instead of **AI**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->