### PR TITLE
feat(navigation): universal footer whitelist, mobile drawer links & chrome refinements

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -52,6 +52,16 @@
         -ms-overflow-style: none; /* IE and Edge */
     }
 
+    button,
+    [role='button'] {
+        cursor: pointer;
+    }
+
+    button:disabled,
+    [role='button'][aria-disabled='true'] {
+        cursor: not-allowed;
+    }
+
     /* Prevent browser autofill from whiting out in dark mode */
     .dark input:-webkit-autofill,
     .dark input:-webkit-autofill:hover,

--- a/resources/js/components/navigation/Navigation.tsx
+++ b/resources/js/components/navigation/Navigation.tsx
@@ -1070,6 +1070,126 @@ export const SiteDrawer = defineComponent({
                                             )}
                                         </nav>
 
+                                        {/* Platform & Community Links */}
+                                        <div class="mt-4 border-t border-slate-100 pt-3 dark:border-slate-800/60">
+                                            <p class="mb-2 px-4 text-[10px] font-bold tracking-[0.12em] text-slate-400 uppercase dark:text-slate-500">
+                                                Platform
+                                            </p>
+                                            <nav class="space-y-0.5 px-2.5">
+                                                <Link
+                                                    href="/about-us"
+                                                    onClick={close}
+                                                    class={[
+                                                        'group flex items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13px] font-medium tracking-tight transition-all duration-150 ease-out',
+                                                        isActive('/about-us')
+                                                            ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200/60 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/20'
+                                                            : 'text-slate-600 hover:bg-slate-100/80 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-100',
+                                                    ]}
+                                                >
+                                                    <MaterialIcon
+                                                        name="groups"
+                                                        size={22}
+                                                        class={`shrink-0 transition-colors duration-150 ${
+                                                            isActive(
+                                                                '/about-us',
+                                                            )
+                                                                ? 'text-indigo-600 dark:text-indigo-300'
+                                                                : 'text-slate-500 group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-300'
+                                                        }`}
+                                                    />
+                                                    <span class="truncate">
+                                                        About Us
+                                                    </span>
+                                                    {isActive('/about-us') && (
+                                                        <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
+                                                    )}
+                                                </Link>
+                                                <Link
+                                                    href="/join"
+                                                    onClick={close}
+                                                    class={[
+                                                        'group flex items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13px] font-medium tracking-tight transition-all duration-150 ease-out',
+                                                        isActive('/join')
+                                                            ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200/60 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/20'
+                                                            : 'text-slate-600 hover:bg-slate-100/80 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-100',
+                                                    ]}
+                                                >
+                                                    <MaterialIcon
+                                                        name="person_add"
+                                                        size={22}
+                                                        class={`shrink-0 transition-colors duration-150 ${
+                                                            isActive('/join')
+                                                                ? 'text-indigo-600 dark:text-indigo-300'
+                                                                : 'text-slate-500 group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-300'
+                                                        }`}
+                                                    />
+                                                    <span class="truncate">
+                                                        Join Our Team
+                                                    </span>
+                                                    {isActive('/join') && (
+                                                        <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
+                                                    )}
+                                                </Link>
+                                                <Link
+                                                    href="/projects"
+                                                    onClick={close}
+                                                    class={[
+                                                        'group flex items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13px] font-medium tracking-tight transition-all duration-150 ease-out',
+                                                        isActive('/projects')
+                                                            ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200/60 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/20'
+                                                            : 'text-slate-600 hover:bg-slate-100/80 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-100',
+                                                    ]}
+                                                >
+                                                    <MaterialIcon
+                                                        name="apps"
+                                                        size={22}
+                                                        class={`shrink-0 transition-colors duration-150 ${
+                                                            isActive(
+                                                                '/projects',
+                                                            )
+                                                                ? 'text-indigo-600 dark:text-indigo-300'
+                                                                : 'text-slate-500 group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-300'
+                                                        }`}
+                                                    />
+                                                    <span class="truncate">
+                                                        More Projects
+                                                    </span>
+                                                    {isActive('/projects') && (
+                                                        <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
+                                                    )}
+                                                </Link>
+                                            </nav>
+                                        </div>
+
+                                        {/* Legal & Info Links */}
+                                        <div class="mt-3 border-t border-slate-100 px-4 pt-3 dark:border-slate-800/60">
+                                            <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] font-medium text-slate-400 dark:text-slate-500">
+                                                <Link
+                                                    href="/privacy-policy"
+                                                    onClick={close}
+                                                    class="transition hover:text-slate-700 dark:hover:text-slate-300"
+                                                >
+                                                    Privacy
+                                                </Link>
+                                                <span>•</span>
+                                                <Link
+                                                    href="/terms-service"
+                                                    onClick={close}
+                                                    class="transition hover:text-slate-700 dark:hover:text-slate-300"
+                                                >
+                                                    Terms
+                                                </Link>
+                                                <span>•</span>
+                                                <Link
+                                                    href="/content-policy"
+                                                    onClick={close}
+                                                    class="transition hover:text-slate-700 dark:hover:text-slate-300"
+                                                >
+                                                    Content Policy
+                                                </Link>
+                                            </div>
+                                        </div>
+
                                         {/* Install */}
                                         <div class="px-2.5">
                                             {canInstallApp.value && (

--- a/resources/js/components/navigation/Navigation.tsx
+++ b/resources/js/components/navigation/Navigation.tsx
@@ -548,32 +548,6 @@ export const SiteRail = defineComponent({
                                         </Link>
                                     </div>
                                 </div>
-
-                                {/* Legal Links */}
-                                <div class="mt-3 border-t border-slate-100 px-3 pt-3 dark:border-slate-800/60">
-                                    <div class="flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[11px] font-medium text-slate-400 dark:text-slate-500">
-                                        <Link
-                                            href="/privacy-policy"
-                                            class="transition hover:text-slate-700 dark:hover:text-slate-300"
-                                        >
-                                            Privacy
-                                        </Link>
-                                        <span>•</span>
-                                        <Link
-                                            href="/terms-service"
-                                            class="transition hover:text-slate-700 dark:hover:text-slate-300"
-                                        >
-                                            Terms
-                                        </Link>
-                                        <span>•</span>
-                                        <Link
-                                            href="/content-policy"
-                                            class="transition hover:text-slate-700 dark:hover:text-slate-300"
-                                        >
-                                            Content Policy
-                                        </Link>
-                                    </div>
-                                </div>
                             </nav>
                         )}
                     </div>

--- a/resources/js/components/navigation/Navigation.tsx
+++ b/resources/js/components/navigation/Navigation.tsx
@@ -464,6 +464,116 @@ export const SiteRail = defineComponent({
                                         )}
                                     </Link>
                                 )}
+
+                                {/* Platform & Community Section */}
+                                <div class="mt-4 border-t border-slate-100 pt-3 dark:border-slate-800/60">
+                                    <p class="mb-2 px-3 text-[10px] font-bold tracking-[0.12em] text-slate-400 uppercase dark:text-slate-500">
+                                        Platform
+                                    </p>
+                                    <div class="space-y-1">
+                                        <Link
+                                            href="/about-us"
+                                            class={[
+                                                'group flex h-10 items-center gap-3 rounded-[10px] px-3 text-[13px] font-medium tracking-tight transition-colors duration-150',
+                                                isActive('/about-us')
+                                                    ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200/60 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/20'
+                                                    : 'text-slate-600 hover:bg-slate-100/80 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-100',
+                                            ]}
+                                        >
+                                            <MaterialIcon
+                                                name="groups"
+                                                size={22}
+                                                class={`shrink-0 transition-colors duration-150 ${
+                                                    isActive('/about-us')
+                                                        ? 'text-indigo-600 dark:text-indigo-300'
+                                                        : 'text-slate-500 group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-300'
+                                                }`}
+                                            />
+                                            <span class="truncate">
+                                                About Us
+                                            </span>
+                                            {isActive('/about-us') && (
+                                                <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
+                                            )}
+                                        </Link>
+                                        <Link
+                                            href="/join"
+                                            class={[
+                                                'group flex h-10 items-center gap-3 rounded-[10px] px-3 text-[13px] font-medium tracking-tight transition-colors duration-150',
+                                                isActive('/join')
+                                                    ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200/60 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/20'
+                                                    : 'text-slate-600 hover:bg-slate-100/80 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-100',
+                                            ]}
+                                        >
+                                            <MaterialIcon
+                                                name="person_add"
+                                                size={22}
+                                                class={`shrink-0 transition-colors duration-150 ${
+                                                    isActive('/join')
+                                                        ? 'text-indigo-600 dark:text-indigo-300'
+                                                        : 'text-slate-500 group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-300'
+                                                }`}
+                                            />
+                                            <span class="truncate">
+                                                Join Our Team
+                                            </span>
+                                            {isActive('/join') && (
+                                                <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
+                                            )}
+                                        </Link>
+                                        <Link
+                                            href="/projects"
+                                            class={[
+                                                'group flex h-10 items-center gap-3 rounded-[10px] px-3 text-[13px] font-medium tracking-tight transition-colors duration-150',
+                                                isActive('/projects')
+                                                    ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200/60 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/20'
+                                                    : 'text-slate-600 hover:bg-slate-100/80 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-100',
+                                            ]}
+                                        >
+                                            <MaterialIcon
+                                                name="apps"
+                                                size={22}
+                                                class={`shrink-0 transition-colors duration-150 ${
+                                                    isActive('/projects')
+                                                        ? 'text-indigo-600 dark:text-indigo-300'
+                                                        : 'text-slate-500 group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-300'
+                                                }`}
+                                            />
+                                            <span class="truncate">
+                                                More From Us
+                                            </span>
+                                            {isActive('/projects') && (
+                                                <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
+                                            )}
+                                        </Link>
+                                    </div>
+                                </div>
+
+                                {/* Legal Links */}
+                                <div class="mt-3 border-t border-slate-100 px-3 pt-3 dark:border-slate-800/60">
+                                    <div class="flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[11px] font-medium text-slate-400 dark:text-slate-500">
+                                        <Link
+                                            href="/privacy-policy"
+                                            class="transition hover:text-slate-700 dark:hover:text-slate-300"
+                                        >
+                                            Privacy
+                                        </Link>
+                                        <span>•</span>
+                                        <Link
+                                            href="/terms-service"
+                                            class="transition hover:text-slate-700 dark:hover:text-slate-300"
+                                        >
+                                            Terms
+                                        </Link>
+                                        <span>•</span>
+                                        <Link
+                                            href="/content-policy"
+                                            class="transition hover:text-slate-700 dark:hover:text-slate-300"
+                                        >
+                                            Content Policy
+                                        </Link>
+                                    </div>
+                                </div>
                             </nav>
                         )}
                     </div>

--- a/resources/js/components/navigation/Navigation.tsx
+++ b/resources/js/components/navigation/Navigation.tsx
@@ -1152,7 +1152,7 @@ export const SiteDrawer = defineComponent({
                                                         }`}
                                                     />
                                                     <span class="truncate">
-                                                        More Projects
+                                                        More From Us
                                                     </span>
                                                     {isActive('/projects') && (
                                                         <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />

--- a/resources/js/components/navigation/Navigation.tsx
+++ b/resources/js/components/navigation/Navigation.tsx
@@ -284,7 +284,12 @@ export const SiteRail = defineComponent({
                             <button
                                 type="button"
                                 onClick={() => emit('toggle')}
-                                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-slate-700 transition-colors hover:bg-slate-100 active:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800"
+                                class={[
+                                    'flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-slate-700 transition-colors hover:bg-slate-100 active:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800',
+                                    props.collapsed
+                                        ? 'cursor-e-resize'
+                                        : 'cursor-w-resize',
+                                ]}
                                 aria-label={
                                     props.collapsed
                                         ? 'Expand sidebar'
@@ -1481,7 +1486,12 @@ export const AdminRail = defineComponent({
                             <button
                                 type="button"
                                 onClick={() => emit('toggle')}
-                                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-slate-700 transition-colors hover:bg-slate-100 active:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800"
+                                class={[
+                                    'flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-slate-700 transition-colors hover:bg-slate-100 active:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800',
+                                    props.collapsed
+                                        ? 'cursor-e-resize'
+                                        : 'cursor-w-resize',
+                                ]}
                                 aria-label={
                                     props.collapsed
                                         ? 'Expand sidebar'

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { usePage } from '@inertiajs/vue3';
 import { computed, ref, watch } from 'vue';
 
 import AtmosphericBackground from '@/components/AtmosphericBackground.vue';
@@ -14,6 +15,8 @@ import ToastNotification from '@/components/ToastNotification.vue';
 import { useBreakpoint } from '@/lib/useBreakpoint';
 import { useOrientation } from '@/lib/useOrientation';
 
+const page = usePage();
+
 const { isLandscape, isHydrated: orientationHydrated } = useOrientation();
 const { isMobile, isHydrated: breakpointHydrated } = useBreakpoint(1024);
 const isHydrated = computed(
@@ -26,6 +29,33 @@ const showSideRail = computed(() =>
 const showBottomNav = computed(() =>
     isHydrated.value ? isMobile.value || !isLandscape.value : false,
 );
+
+// Whitelisted pages that show the marketing footer on desktop
+const DESKTOP_FOOTER_COMPONENTS = new Set([
+    'Home',
+    'Blog/Index',
+    'Forum/Index',
+    'Donate',
+    'Projects',
+    'Support',
+    'SupportMyTickets',
+    'ContributorGuide',
+    'platform/AboutUs',
+    'platform/JoinTeam',
+    'legal/PrivacyPolicy',
+    'legal/TermsConditions',
+    'legal/ContentPolicy',
+]);
+
+const showFooter = computed(() => {
+    // Mobile / Portrait: only show on Home landing page
+    if (showBottomNav.value) {
+        return page.component === 'Home';
+    }
+
+    // Desktop / Landscape: only show on whitelisted discovery & marketing pages
+    return DESKTOP_FOOTER_COMPONENTS.has(page.component);
+});
 
 const railCollapsed = ref(false);
 
@@ -88,12 +118,9 @@ const drawerOpen = ref(false);
                     <slot />
                 </main>
 
-                <!-- Footer: shown on desktop across pages (except Chat/Index); on mobile/portrait shown ONLY on Home/SSC landing pages -->
+                <!-- Footer: whitelisted desktop pages + mobile Home -->
                 <div
-                    v-if="
-                        $page.component !== 'Chat/Index' &&
-                        (!showBottomNav || $page.component === 'Home')
-                    "
+                    v-if="showFooter"
                     :class="
                         showBottomNav
                             ? 'pb-[calc(4.5rem+env(safe-area-inset-bottom))]'

--- a/resources/js/pages/Chat/Index.vue
+++ b/resources/js/pages/Chat/Index.vue
@@ -1494,7 +1494,7 @@ onUnmounted(() => {
 
         <!-- Main Messenger Shell -->
         <div
-            class="flex h-[calc(100dvh-13.5rem)] max-h-[760px] min-h-[480px] flex-col overflow-hidden rounded-2xl border border-slate-200/90 bg-white shadow-xs sm:h-[calc(100dvh-15rem)] dark:border-zinc-800 dark:bg-zinc-900"
+            class="flex h-[calc(100dvh-13.5rem)] min-h-[480px] flex-col overflow-hidden rounded-2xl border border-slate-200/90 bg-white shadow-xs sm:h-[calc(100dvh-8.5rem)] dark:border-zinc-800 dark:bg-zinc-900"
         >
             <!-- Scrollable Message Stream -->
             <div


### PR DESCRIPTION
### Summary of Changes

1. **Footer Whitelist Architecture (`AppLayout.vue`)**:
   - Replaced complex conditional checks with a centralized component whitelist for desktop footer rendering.
   - Restricts footer rendering strictly to public discovery & marketing pages (`Home`, `Blog/Index`, `Forum/Index`, `Donate`, `Projects`, `Support`, `SupportMyTickets`, `ContributorGuide`, `platform/AboutUs`, `platform/JoinTeam`, `legal/*`).
   - Omitted from workspace, reading, auth, and profile views (`Chat/Index`, `Forum/Show`, `Blog/Show`, `Resource`, `Node`, `Profile`, `User/Show`, `auth/Login`).
   - On mobile viewports (`showBottomNav`), the footer is exclusively rendered on `Home.vue` to prevent bottom bar clutter.

2. **Mobile Drawer Enhancements (`SiteDrawer` in `Navigation.tsx`)**:
   - Added dedicated **Platform** section: **About Us**, **Join Our Team**, **More From Us**.
   - Added dedicated **Legal** row: **Privacy • Terms • Content Policy**.

3. **Desktop Side Rail Enhancements (`SiteRail` in `Navigation.tsx`)**:
   - Added **Platform** section (**About Us**, **Join Our Team**, **More From Us**) to the expanded 280px sidebar.
   - Added directional horizontal expand/collapse resize cursors (`cursor-e-resize` / `cursor-w-resize`) to the sidebar toggle buttons.

4. **Desktop Chat Height Fix (`Chat/Index.vue`)**:
   - Removed `max-h-[760px]` cap and adjusted desktop viewport subtraction from `sm:h-[calc(100dvh-15rem)]` to `sm:h-[calc(100dvh-8.5rem)]` to fill viewport smoothly without gaps.

5. **Global Button Cursor Reset (`app.css`)**:
   - Added global `button, [role="button"] { cursor: pointer; }` to ensure all interactive buttons exhibit hand pointers on hover.