### PR TITLE
fix(css): remove global body color transition to prevent refresh flash

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -35,7 +35,7 @@
     html,
     body {
         font-stretch: 96%;
-        @apply bg-slate-50 transition-colors duration-300 dark:bg-gray-950;
+        @apply bg-slate-50 dark:bg-gray-950;
         scrollbar-width: none; /* Firefox */
         -ms-overflow-style: none; /* IE and Edge */
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Light and dark mode background color changes now occur without animation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->