### PR TITLE
revert: restore pre-#317 viewport and keep GEMINI.md guidelines

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -18,7 +18,7 @@
                 } catch (_) {}
             })();
         </script>
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=overlays-content">
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
         <meta name="csrf-token" content="{{ csrf_token() }}">
         <meta name="color-scheme" content="light dark">
         {{-- Browser chrome: top status bar + bottom nav bar (Chrome / Edge / Samsung Internet) --}}


### PR DESCRIPTION
Reverts all changes introduced after PR #316 (restoring default viewport without overlays-content) while preserving the updated GEMINI.md guidelines.