### PR TITLE
feat: add trending forum discussions to home and refine mobile blog card

### DIFF
--- a/app/Helpers/CacheHelper.php
+++ b/app/Helpers/CacheHelper.php
@@ -17,6 +17,7 @@ class CacheHelper
         Cache::forget('home_page_subjects_hsc');
         Cache::forget('home_page_subjects_ssc');
         Cache::forget('home_page_featured_blogs');
+        Cache::forget('home_page_trending_posts');
         Cache::forget('home_page_notice');
         Cache::forget('forum_filter_subjects');
     }

--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Blog;
+use App\Models\ForumPost;
 use App\Models\Node;
 use App\Models\Notice;
 use App\Models\Subject;
@@ -41,6 +42,21 @@ class SubjectController extends Controller
                 ->toArray();
         });
 
+        $trendingPosts = Cache::remember('home_page_trending_posts', now()->addHours(2), function () {
+            return ForumPost::query()
+                ->approved()
+                ->with([
+                    'user:id,name,username,image_path,institution,is_verified',
+                    'subject:id,name,course,slug',
+                    'node:id,name,slug',
+                ])
+                ->orderByDesc('vote_score')
+                ->latest()
+                ->limit(4)
+                ->get()
+                ->toArray();
+        });
+
         $notice = Cache::rememberForever('home_page_notice', function () {
             return Notice::activeForDisplay()?->toArray();
         });
@@ -48,6 +64,7 @@ class SubjectController extends Controller
         return Inertia::render('Home', [
             'subjects' => $subjects,
             'featured_blogs' => $featuredBlogs,
+            'trending_posts' => $trendingPosts,
             'notice' => $notice,
         ]);
     }

--- a/resources/js/components/BlogCard.vue
+++ b/resources/js/components/BlogCard.vue
@@ -1,27 +1,66 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
-import { ArrowRight, Heart, MessageSquare } from 'lucide-vue-next';
+import {
+    ArrowRight,
+    BookOpen,
+    Eye,
+    Heart,
+    MessageSquare,
+} from 'lucide-vue-next';
+import { formatTimeAgo } from '@/lib/useDate';
 
-defineProps({
-    blog: Object,
-});
+interface User {
+    id?: number;
+    name?: string;
+    username?: string;
+    image_url?: string | null;
+}
+
+interface Blog {
+    id: number;
+    title: string;
+    slug: string;
+    excerpt?: string | null;
+    category?: string | null;
+    featured_image?: string | null;
+    featured_image_path?: string | null;
+    is_featured?: boolean;
+    views?: number;
+    reactions_count?: number;
+    comments_count?: number;
+    created_at?: string;
+    user?: User;
+}
+
+defineProps<{
+    blog: Blog;
+}>();
 </script>
 
 <template>
     <Link
         :href="'/blogs/' + blog.slug"
-        class="group relative flex flex-row items-center overflow-hidden rounded-xl border border-slate-200 bg-white p-3 shadow-xs transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md sm:flex-col sm:p-0 dark:border-gray-700 dark:bg-gray-900 dark:hover:shadow-gray-900/50"
+        class="group relative flex touch-manipulation flex-row items-center overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-3 shadow-xs transition-all duration-200 hover:border-indigo-300/80 hover:shadow-sm active:scale-[0.99] sm:flex-col sm:items-stretch sm:p-0 sm:active:scale-100 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-indigo-500/40 dark:hover:shadow-indigo-500/5"
     >
         <!-- Featured Image Container -->
         <div
-            class="relative block h-20 w-20 shrink-0 overflow-hidden rounded-lg bg-slate-100 sm:aspect-[16/9] sm:h-auto sm:w-full sm:rounded-none dark:bg-gray-800"
+            class="relative h-20 w-24 shrink-0 overflow-hidden rounded-xl bg-slate-100 sm:aspect-[16/9] sm:h-auto sm:w-full sm:rounded-none dark:bg-gray-800"
         >
             <img
-                :src="blog.featured_image || 'https://placehold.co/600x400'"
+                v-if="blog.featured_image"
+                :src="blog.featured_image"
                 :alt="blog.title"
                 class="h-full w-full object-cover transition-transform duration-300 ease-out group-hover:scale-105"
                 loading="lazy"
             />
+            <div
+                v-else
+                class="flex h-full w-full items-center justify-center bg-slate-100 text-slate-400 dark:bg-gray-800 dark:text-gray-500"
+            >
+                <BookOpen class="h-6 w-6 stroke-[1.8] opacity-60" />
+            </div>
+
+            <!-- Desktop Category Badge (on image) -->
             <div
                 v-if="blog.category"
                 class="absolute top-2.5 left-2.5 hidden rounded-md bg-indigo-600 px-2 py-0.5 text-[10px] font-bold tracking-wider text-white uppercase shadow-xs sm:block"
@@ -31,45 +70,46 @@ defineProps({
         </div>
 
         <!-- Card Body -->
-        <div class="flex min-w-0 flex-1 flex-col justify-between pl-3 sm:p-4">
+        <div class="flex min-w-0 flex-1 flex-col justify-between pl-3 sm:p-4.5">
             <div>
-                <!-- Top Row: Category / Author -->
+                <!-- Top Row: Category / Author / Date -->
                 <div
                     class="mb-1 flex items-center gap-1.5 text-[11px] sm:mb-1.5 sm:text-xs"
                 >
                     <span
                         v-if="blog.category"
-                        class="rounded bg-indigo-50 px-1.5 py-0.5 text-[9px] font-bold text-indigo-600 sm:hidden dark:bg-indigo-950/60 dark:text-indigo-400"
+                        class="rounded-md bg-indigo-50 px-1.5 py-0.5 text-[10px] font-bold text-indigo-600 sm:hidden dark:bg-indigo-950/60 dark:text-indigo-400"
                     >
                         {{ blog.category }}
                     </span>
 
-                    <span class="text-slate-400 dark:text-gray-500">By</span>
-                    <Link
-                        v-if="blog.user?.username"
-                        :href="`/u/${blog.user.username}`"
-                        @click.stop
-                        class="relative z-10 truncate font-semibold text-slate-700 transition-colors hover:text-indigo-600 hover:underline dark:text-gray-300 dark:hover:text-indigo-400"
-                    >
-                        {{ blog.user?.name }}
-                    </Link>
                     <span
-                        v-else
+                        v-if="blog.user?.name"
                         class="truncate font-semibold text-slate-700 dark:text-gray-300"
                     >
-                        {{ blog.user?.name }}
+                        {{ blog.user.name }}
                     </span>
+
+                    <template v-if="blog.created_at">
+                        <span class="text-slate-300 dark:text-gray-600">•</span>
+                        <span
+                            class="shrink-0 text-slate-400 dark:text-gray-500"
+                        >
+                            {{ formatTimeAgo(blog.created_at) }}
+                        </span>
+                    </template>
                 </div>
 
                 <!-- Title -->
                 <h3
-                    class="line-clamp-2 text-xs leading-snug font-bold text-slate-900 transition duration-150 group-hover:text-indigo-600 sm:text-base dark:text-gray-100 dark:group-hover:text-indigo-400"
+                    class="line-clamp-2 text-sm leading-snug font-bold text-slate-900 transition-colors duration-150 group-hover:text-indigo-600 sm:text-base dark:text-gray-100 dark:group-hover:text-indigo-400"
                 >
                     {{ blog.title }}
                 </h3>
 
-                <!-- Excerpt (hidden on mobile to save vertical space) -->
+                <!-- Excerpt (hidden on mobile to maintain compact height) -->
                 <p
+                    v-if="blog.excerpt"
                     class="mt-1.5 mb-3 line-clamp-2 hidden text-xs leading-relaxed text-slate-600 sm:block dark:text-gray-400"
                 >
                     {{ blog.excerpt }}
@@ -78,27 +118,35 @@ defineProps({
 
             <!-- Footer Action & Interaction Stats -->
             <div
-                class="mt-1 flex items-center justify-between pt-1 sm:mt-auto sm:border-t sm:border-slate-100 sm:pt-3 dark:sm:border-gray-800"
+                class="mt-1.5 flex items-center justify-between pt-0.5 sm:mt-auto sm:border-t sm:border-slate-100 sm:pt-3 dark:sm:border-gray-800/80"
             >
                 <div
                     class="flex items-center gap-3 text-[11px] text-slate-400 sm:text-xs dark:text-gray-500"
                 >
                     <span class="inline-flex items-center gap-1">
-                        <Heart class="h-3.5 w-3.5" />
+                        <Heart class="h-3.5 w-3.5 stroke-[2]" />
                         <span>{{ blog.reactions_count || 0 }}</span>
                     </span>
 
                     <span class="inline-flex items-center gap-1">
-                        <MessageSquare class="h-3.5 w-3.5" />
+                        <MessageSquare class="h-3.5 w-3.5 stroke-[2]" />
                         <span>{{ blog.comments_count || 0 }}</span>
+                    </span>
+
+                    <span
+                        v-if="blog.views"
+                        class="inline-flex items-center gap-1"
+                    >
+                        <Eye class="h-3.5 w-3.5 stroke-[2]" />
+                        <span>{{ blog.views }}</span>
                     </span>
                 </div>
 
-                <!-- Bottom-Right Arrow Indicator -->
+                <!-- Arrow Indicator matching platform style -->
                 <div
-                    class="flex h-5 w-5 shrink-0 items-center justify-center text-slate-400 transition-transform duration-200 group-hover:translate-x-1 group-hover:text-indigo-600 dark:text-gray-500 dark:group-hover:text-indigo-400"
+                    class="flex h-5 w-5 shrink-0 items-center justify-center text-slate-300 transition-all duration-200 group-hover:translate-x-0.5 group-hover:text-indigo-600 dark:text-gray-600 dark:group-hover:text-indigo-400"
                 >
-                    <ArrowRight class="h-3.5 w-3.5" />
+                    <ArrowRight class="h-3.5 w-3.5 stroke-[2]" />
                 </div>
             </div>
         </div>

--- a/resources/js/components/forum/ForumPostCard.vue
+++ b/resources/js/components/forum/ForumPostCard.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { Link, router } from '@inertiajs/vue3';
+import { CheckCircle2, ImageIcon, MessageSquare } from 'lucide-vue-next';
+import ForumVoteButtons from '@/components/forum/ForumVoteButtons.vue';
+import VerifiedBadge from '@/components/VerifiedBadge.vue';
+import { formatTimeAgo } from '@/lib/useDate';
+
+interface User {
+    id: number;
+    name: string;
+    username: string;
+    image_path?: string | null;
+    image_url?: string | null;
+    institution?: string | null;
+    is_verified?: boolean;
+}
+
+interface NodeItem {
+    id: number;
+    subject_id?: number;
+    name: string;
+    slug: string;
+}
+
+interface Subject {
+    id: number;
+    name: string;
+    course: 'hsc' | 'ssc';
+    slug: string;
+}
+
+interface ForumPost {
+    id: number;
+    user_id?: number;
+    subject_id?: number | null;
+    node_id?: number | null;
+    curriculum: 'hsc' | 'ssc';
+    title: string;
+    slug: string;
+    body?: string | null;
+    image_path?: string | null;
+    image_url?: string | null;
+    is_answered?: boolean;
+    vote_score: number;
+    upvotes_count?: number;
+    downvotes_count?: number;
+    answers_count: number;
+    created_at: string;
+    user?: User;
+    subject?: Subject | null;
+    node?: NodeItem | null;
+    user_vote?: number | null;
+}
+
+defineProps<{
+    post: ForumPost;
+}>();
+</script>
+
+<template>
+    <article
+        class="group cursor-pointer rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs transition duration-150 hover:border-slate-300 hover:shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:hover:border-gray-700"
+        @click="router.visit('/forum/questions/' + post.slug)"
+    >
+        <div class="flex items-start gap-3 sm:gap-4">
+            <!-- Left: Vote Controls (Vertical on all screens) -->
+            <div class="shrink-0 pt-0.5" @click.stop>
+                <ForumVoteButtons
+                    votableType="post"
+                    :votableId="post.id"
+                    :initialUpvotes="post.upvotes_count || 0"
+                    :initialDownvotes="post.downvotes_count || 0"
+                    :initialUserVote="post.user_vote"
+                    direction="vertical"
+                    size="sm"
+                />
+            </div>
+
+            <!-- Right: Content Body -->
+            <div class="min-w-0 flex-1">
+                <!-- Badges Row -->
+                <div
+                    class="mb-1.5 flex flex-wrap items-center gap-1.5 text-[11px]"
+                >
+                    <!-- Curriculum Badge -->
+                    <span
+                        class="rounded-md px-1.5 py-0.5 font-bold uppercase"
+                        :class="[
+                            post.curriculum === 'ssc'
+                                ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-400'
+                                : 'bg-indigo-50 text-indigo-700 dark:bg-indigo-950/60 dark:text-indigo-400',
+                        ]"
+                    >
+                        {{ post.curriculum }}
+                    </span>
+
+                    <!-- Subject Badge -->
+                    <span
+                        v-if="post.subject"
+                        class="rounded-md bg-slate-100 px-1.5 py-0.5 font-medium text-slate-700 dark:bg-gray-800 dark:text-gray-300"
+                    >
+                        {{ post.subject.name }}
+                    </span>
+                    <span
+                        v-else
+                        class="rounded-md bg-slate-100 px-1.5 py-0.5 font-medium text-slate-500 dark:bg-gray-800 dark:text-gray-400"
+                    >
+                        Other / General
+                    </span>
+
+                    <!-- Chapter Badge -->
+                    <span
+                        v-if="post.node"
+                        class="rounded-md bg-slate-100 px-1.5 py-0.5 font-medium text-slate-600 dark:bg-gray-800 dark:text-gray-400"
+                    >
+                        # {{ post.node.name }}
+                    </span>
+
+                    <!-- Answered Badge -->
+                    <span
+                        v-if="post.is_answered"
+                        class="inline-flex items-center gap-1 rounded-md bg-emerald-100/70 px-1.5 py-0.5 font-bold text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
+                    >
+                        <CheckCircle2
+                            class="h-3 w-3 text-emerald-600 dark:text-emerald-400"
+                        />
+                        <span>Answered</span>
+                    </span>
+                </div>
+
+                <!-- Question Title -->
+                <h2
+                    class="text-base font-bold text-slate-900 transition sm:text-lg dark:text-gray-100"
+                >
+                    <Link
+                        :href="`/forum/questions/${post.slug}`"
+                        class="hover:text-indigo-600 dark:hover:text-indigo-400"
+                    >
+                        {{ post.title }}
+                    </Link>
+                </h2>
+
+                <!-- Preview snippet -->
+                <p
+                    v-if="post.body"
+                    class="mt-1 line-clamp-2 text-xs leading-relaxed text-slate-600 sm:text-sm dark:text-gray-300"
+                >
+                    {{ post.body }}
+                </p>
+
+                <!-- Attached Image Indicator (if any) -->
+                <div
+                    v-if="post.image_url"
+                    class="mt-2 inline-flex items-center gap-1 text-xs text-slate-400 dark:text-gray-500"
+                >
+                    <ImageIcon class="h-3.5 w-3.5" />
+                    <span>Image attached</span>
+                </div>
+
+                <!-- Footer Author & Stats Metadata -->
+                <div
+                    class="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-slate-100 pt-2.5 text-xs text-slate-400 dark:border-gray-800/80 dark:text-gray-500"
+                >
+                    <!-- Author info -->
+                    <div class="flex items-center gap-1.5">
+                        <Link
+                            v-if="post.user?.username"
+                            :href="`/u/${post.user.username}`"
+                            @click.stop
+                            class="inline-flex items-center gap-1.5 font-medium text-slate-700 hover:text-indigo-600 hover:underline dark:text-gray-300 dark:hover:text-indigo-400"
+                        >
+                            <div
+                                class="flex h-5 w-5 items-center justify-center overflow-hidden rounded-full bg-slate-200 text-[10px] font-bold text-slate-700 dark:bg-gray-700 dark:text-gray-300"
+                            >
+                                <img
+                                    v-if="post.user.image_url"
+                                    :src="post.user.image_url"
+                                    :alt="post.user.name"
+                                    class="h-full w-full object-cover"
+                                />
+                                <span v-else>{{
+                                    post.user.name.charAt(0)
+                                }}</span>
+                            </div>
+                            <span>{{ post.user.name }}</span>
+                            <VerifiedBadge v-if="post.user.is_verified" />
+                        </Link>
+                        <span
+                            v-else
+                            class="font-medium text-slate-700 dark:text-gray-300"
+                        >
+                            {{ post.user?.name || 'Anonymous' }}
+                        </span>
+
+                        <span
+                            v-if="post.user?.institution"
+                            class="hidden text-slate-400 sm:inline dark:text-gray-500"
+                        >
+                            ({{ post.user.institution }})
+                        </span>
+
+                        <span>•</span>
+                        <span>{{ formatTimeAgo(post.created_at) }}</span>
+                    </div>
+
+                    <!-- Answer count badge -->
+                    <div class="flex items-center gap-3">
+                        <span
+                            class="inline-flex items-center gap-1 font-medium"
+                            :class="
+                                post.answers_count > 0
+                                    ? 'text-indigo-600 dark:text-indigo-400'
+                                    : 'text-slate-400 dark:text-gray-500'
+                            "
+                        >
+                            <MessageSquare class="h-3.5 w-3.5" />
+                            <span
+                                >{{ post.answers_count }}
+                                {{
+                                    post.answers_count === 1
+                                        ? 'answer'
+                                        : 'answers'
+                                }}</span
+                            >
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </article>
+</template>

--- a/resources/js/pages/Forum/Index.vue
+++ b/resources/js/pages/Forum/Index.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
-import { Head, Link, router } from '@inertiajs/vue3';
+import { Head, router } from '@inertiajs/vue3';
 import {
     Search,
     X,
     Plus,
-    MessageSquare,
-    CheckCircle2,
-    ImageIcon,
     SlidersHorizontal,
     RotateCcw,
     Check,
@@ -16,12 +13,10 @@ import { computed, ref, watch } from 'vue';
 import AuthModal from '@/components/AuthModal.vue';
 import BaseModal from '@/components/BaseModal.vue';
 import EmptyState from '@/components/EmptyState.vue';
-import ForumVoteButtons from '@/components/forum/ForumVoteButtons.vue';
+import ForumPostCard from '@/components/forum/ForumPostCard.vue';
 import Pagination from '@/components/Pagination.vue';
 import PwaInstallPrompt from '@/components/PwaInstallPrompt.vue';
-import VerifiedBadge from '@/components/VerifiedBadge.vue';
 import { useAuth } from '@/lib/useAuth';
-import { formatTimeAgo } from '@/lib/useDate';
 
 interface User {
     id: number;
@@ -360,8 +355,6 @@ const handleAskQuestion = () => {
         router.visit('/forum/ask');
     }
 };
-
-const timeAgo = formatTimeAgo;
 </script>
 
 <template>
@@ -634,180 +627,11 @@ const timeAgo = formatTimeAgo;
 
         <!-- Post List Feed -->
         <div v-if="posts.data.length > 0" class="space-y-3">
-            <article
+            <ForumPostCard
                 v-for="post in posts.data"
                 :key="post.id"
-                class="group cursor-pointer rounded-2xl border border-slate-200/80 bg-white p-4 shadow-xs transition duration-150 hover:border-slate-300 hover:shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:hover:border-gray-700"
-                @click="router.visit('/forum/questions/' + post.slug)"
-            >
-                <div class="flex items-start gap-3 sm:gap-4">
-                    <!-- Left: Vote Controls (Vertical on all screens) -->
-                    <div class="shrink-0 pt-0.5" @click.stop>
-                        <ForumVoteButtons
-                            votableType="post"
-                            :votableId="post.id"
-                            :initialUpvotes="post.upvotes_count"
-                            :initialDownvotes="post.downvotes_count"
-                            :initialUserVote="post.user_vote"
-                            direction="vertical"
-                            size="sm"
-                        />
-                    </div>
-
-                    <!-- Right: Content Body -->
-                    <div class="min-w-0 flex-1">
-                        <!-- Badges Row -->
-                        <div
-                            class="mb-1.5 flex flex-wrap items-center gap-1.5 text-[11px]"
-                        >
-                            <!-- Curriculum Badge -->
-                            <span
-                                class="rounded-md px-1.5 py-0.5 font-bold uppercase"
-                                :class="[
-                                    post.curriculum === 'ssc'
-                                        ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-400'
-                                        : 'bg-indigo-50 text-indigo-700 dark:bg-indigo-950/60 dark:text-indigo-400',
-                                ]"
-                            >
-                                {{ post.curriculum }}
-                            </span>
-
-                            <!-- Subject Badge -->
-                            <span
-                                v-if="post.subject"
-                                class="rounded-md bg-slate-100 px-1.5 py-0.5 font-medium text-slate-700 dark:bg-gray-800 dark:text-gray-300"
-                            >
-                                {{ post.subject.name }}
-                            </span>
-                            <span
-                                v-else
-                                class="rounded-md bg-slate-100 px-1.5 py-0.5 font-medium text-slate-500 dark:bg-gray-800 dark:text-gray-400"
-                            >
-                                Other / General
-                            </span>
-
-                            <!-- Chapter Badge -->
-                            <span
-                                v-if="post.node"
-                                class="rounded-md bg-slate-100 px-1.5 py-0.5 font-medium text-slate-600 dark:bg-gray-800 dark:text-gray-400"
-                            >
-                                # {{ post.node.name }}
-                            </span>
-
-                            <!-- Answered Badge -->
-                            <span
-                                v-if="post.is_answered"
-                                class="inline-flex items-center gap-1 rounded-md bg-emerald-100/70 px-1.5 py-0.5 font-bold text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
-                            >
-                                <CheckCircle2
-                                    class="h-3 w-3 text-emerald-600 dark:text-emerald-400"
-                                />
-                                <span>Answered</span>
-                            </span>
-                        </div>
-
-                        <!-- Question Title -->
-                        <h2
-                            class="text-base font-bold text-slate-900 transition sm:text-lg dark:text-gray-100"
-                        >
-                            <Link
-                                :href="`/forum/questions/${post.slug}`"
-                                class="hover:text-indigo-600 dark:hover:text-indigo-400"
-                            >
-                                {{ post.title }}
-                            </Link>
-                        </h2>
-
-                        <!-- Preview snippet -->
-                        <p
-                            v-if="post.body"
-                            class="mt-1 line-clamp-2 text-xs leading-relaxed text-slate-600 sm:text-sm dark:text-gray-300"
-                        >
-                            {{ post.body }}
-                        </p>
-
-                        <!-- Attached Image Indicator (if any) -->
-                        <div
-                            v-if="post.image_url"
-                            class="mt-2 inline-flex items-center gap-1 text-xs text-slate-400 dark:text-gray-500"
-                        >
-                            <ImageIcon class="h-3.5 w-3.5" />
-                            <span>Image attached</span>
-                        </div>
-
-                        <!-- Footer Author & Stats Metadata -->
-                        <div
-                            class="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-slate-100 pt-2.5 text-xs text-slate-400 dark:border-gray-800/80 dark:text-gray-500"
-                        >
-                            <!-- Author info -->
-                            <div class="flex items-center gap-1.5">
-                                <Link
-                                    v-if="post.user?.username"
-                                    :href="`/u/${post.user.username}`"
-                                    @click.stop
-                                    class="inline-flex items-center gap-1.5 font-medium text-slate-700 hover:text-indigo-600 hover:underline dark:text-gray-300 dark:hover:text-indigo-400"
-                                >
-                                    <div
-                                        class="flex h-5 w-5 items-center justify-center overflow-hidden rounded-full bg-slate-200 text-[10px] font-bold text-slate-700 dark:bg-gray-700 dark:text-gray-300"
-                                    >
-                                        <img
-                                            v-if="post.user.image_url"
-                                            :src="post.user.image_url"
-                                            :alt="post.user.name"
-                                            class="h-full w-full object-cover"
-                                        />
-                                        <span v-else>{{
-                                            post.user.name.charAt(0)
-                                        }}</span>
-                                    </div>
-                                    <span>{{ post.user.name }}</span>
-                                    <VerifiedBadge
-                                        v-if="post.user.is_verified"
-                                    />
-                                </Link>
-                                <span
-                                    v-else
-                                    class="font-medium text-slate-700 dark:text-gray-300"
-                                >
-                                    {{ post.user?.name || 'Anonymous' }}
-                                </span>
-
-                                <span
-                                    v-if="post.user?.institution"
-                                    class="hidden text-slate-400 sm:inline dark:text-gray-500"
-                                >
-                                    ({{ post.user.institution }})
-                                </span>
-
-                                <span>•</span>
-                                <span>{{ timeAgo(post.created_at) }}</span>
-                            </div>
-
-                            <!-- Answer count badge -->
-                            <div class="flex items-center gap-3">
-                                <span
-                                    class="inline-flex items-center gap-1 font-medium"
-                                    :class="
-                                        post.answers_count > 0
-                                            ? 'text-indigo-600 dark:text-indigo-400'
-                                            : 'text-slate-400 dark:text-gray-500'
-                                    "
-                                >
-                                    <MessageSquare class="h-3.5 w-3.5" />
-                                    <span
-                                        >{{ post.answers_count }}
-                                        {{
-                                            post.answers_count === 1
-                                                ? 'answer'
-                                                : 'answers'
-                                        }}</span
-                                    >
-                                </span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </article>
+                :post="post"
+            />
         </div>
 
         <!-- Empty State -->

--- a/resources/js/pages/Home.vue
+++ b/resources/js/pages/Home.vue
@@ -5,6 +5,7 @@ import { computed } from 'vue';
 import BlogCard from '@/components/BlogCard.vue';
 import CourseSwitcher from '@/components/CourseSwitcher.vue';
 import EmptyState from '@/components/EmptyState.vue';
+import ForumPostCard from '@/components/forum/ForumPostCard.vue';
 import HomeHeader from '@/components/HomeHeader.vue';
 import NoticeDialog from '@/components/NoticeDialog.vue';
 import PwaInstallPrompt from '@/components/PwaInstallPrompt.vue';
@@ -16,6 +17,7 @@ const props = defineProps({
     subjects: Array,
     notice: Object,
     featured_blogs: Array,
+    trending_posts: Array,
 });
 
 const subjects = props.subjects as Array<{
@@ -92,6 +94,59 @@ const filteredSubjects = computed(() => {
                 Show all subjects
             </button>
         </EmptyState>
+
+        <div
+            v-if="trending_posts?.length"
+            class="mt-10 border-t border-slate-100 pt-8 sm:mt-12 sm:pt-10 dark:border-gray-800"
+        >
+            <div class="mb-6 flex items-center justify-between">
+                <div>
+                    <h2
+                        class="text-2xl font-bold tracking-tight text-slate-900 dark:text-gray-100"
+                    >
+                        Trending Discussions
+                    </h2>
+                    <p class="text-sm text-slate-500 dark:text-gray-400">
+                        ফোরামের সাম্প্রতিক প্রশ্ন ও উত্তরগুলো দেখুন
+                    </p>
+                </div>
+                <!-- Desktop Link -->
+                <Link
+                    href="/forum"
+                    class="group hidden items-center gap-2 text-sm font-semibold text-indigo-600 transition hover:text-indigo-700 sm:inline-flex dark:text-indigo-400 dark:hover:text-indigo-300"
+                >
+                    <span>Visit Forum</span>
+                    <span
+                        class="transition-transform duration-200 group-hover:translate-x-1"
+                    >
+                        →
+                    </span>
+                </Link>
+            </div>
+
+            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
+                <ForumPostCard
+                    v-for="post in trending_posts"
+                    :key="post.id"
+                    :post="post"
+                />
+            </div>
+
+            <!-- Mobile Bottom Link -->
+            <div class="mt-4 text-center sm:hidden">
+                <Link
+                    href="/forum"
+                    class="group inline-flex items-center gap-1.5 py-1 text-xs font-bold text-indigo-600 transition hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                >
+                    <span>Visit Forum</span>
+                    <span
+                        class="transition-transform duration-200 group-hover:translate-x-1"
+                    >
+                        →
+                    </span>
+                </Link>
+            </div>
+        </div>
 
         <div
             v-if="featured_blogs?.length"


### PR DESCRIPTION
## Summary
- **Mobile Blog Card:** Refactored `BlogCard.vue` to use a compact side-by-side row on mobile and responsive vertical card on desktop, displaying view counts, upvotes, comments, author, and relative timestamp.
- **Trending Forum Section on Home:** Added 4 trending approved discussions unified across curricula to `Home.vue` in a 2-column grid.
- **Reusable Forum Post Card:** Extracted `ForumPostCard.vue` from `Forum/Index.vue` for reuse across the platform.
- **Backend & Caching:** Added `home_page_trending_posts` cached query (2h TTL) in `SubjectController.php` and cache clearing in `CacheHelper.php`.

## Verification
- Automated linting and formatting passed (`npm run format && composer lint && npm run lint`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Trending Discussions” section to the home page, showing up to four popular forum questions with links to visit the forum.
  - Introduced richer forum question cards with voting controls, topic badges, previews, answer counts, author details, timestamps, and image indicators.
  - Added trending forum discussions to the home page based on popularity and recency.

- **Enhancements**
  - Improved blog cards with excerpts, relative publication times, view counts, refined styling, and responsive layouts.
  - Standardized forum post presentation across the forum page and home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->