### PR TITLE
fix(auth): redirect authenticated users to /me instead of /admin

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -20,7 +20,7 @@ class AuthController extends Controller
     public function index()
     {
         if (Auth::check()) {
-            return redirect()->route('admin.index');
+            return redirect()->route('me');
         }
 
         return Inertia::render('auth/Login');
@@ -29,7 +29,7 @@ class AuthController extends Controller
     public function redirectToGoogle(Request $request)
     {
         if (Auth::check()) {
-            return redirect()->route('admin.index');
+            return redirect()->route('me');
         }
 
         if ($request->filled('redirect')) {

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -8,13 +8,29 @@ use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Socialite\Facades\Socialite;
 
-test('login page is accessible', function () {
+test('login page is accessible for guests', function () {
     $response = $this->get('/login');
 
     $response->assertStatus(200);
 });
 
-test('redirects to google for authentication', function () {
+test('login page redirects authenticated users to /me', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('/login');
+
+    $response->assertRedirect(route('me'));
+});
+
+test('google auth redirects authenticated users to /me', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('auth.google'));
+
+    $response->assertRedirect(route('me'));
+});
+
+test('redirects to google for authentication for guests', function () {
     $response = $this->get(route('auth.google'));
 
     $response->assertRedirect();


### PR DESCRIPTION
### Summary
- Updated `AuthController::index` and `AuthController::redirectToGoogle` to redirect already-authenticated users to `/me` (`route('me')`) instead of `/admin` (`route('admin.index')`).
- Added feature tests covering authenticated redirects for `/login` and `/auth/google`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Authenticated users who visit the login page are now redirected to their account page instead of the admin dashboard.
  - Authenticated users who start Google sign-in are also redirected to their account page.
  - Guests can continue accessing the login page and Google sign-in flow as before.

- **Tests**
  - Added coverage to verify the updated redirects for authenticated users and preserve guest authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->