### PR TITLE
fix(subject): remove unique validation rule on subject name

### DIFF
--- a/app/Http/Requests/Subject/StoreSubjectRequest.php
+++ b/app/Http/Requests/Subject/StoreSubjectRequest.php
@@ -35,7 +35,7 @@ class StoreSubjectRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:100', 'min:3', 'unique:subjects,name'],
+            'name' => ['required', 'string', 'max:100', 'min:3'],
             'english_name' => ['nullable', 'string', 'max:100'],
             'slug' => ['required', 'string', 'max:100', 'unique:subjects,slug'],
             'tailwind_format' => ['required', 'string', 'max:100'],

--- a/app/Http/Requests/Subject/UpdateSubjectRequest.php
+++ b/app/Http/Requests/Subject/UpdateSubjectRequest.php
@@ -36,7 +36,7 @@ class UpdateSubjectRequest extends FormRequest
         $subject = $this->route('subject');
 
         return [
-            'name' => ['sometimes', 'string', 'max:100', 'min:3', Rule::unique('subjects', 'name')->ignore($subject->id)],
+            'name' => ['sometimes', 'string', 'max:100', 'min:3'],
             'english_name' => ['nullable', 'string', 'max:100'],
             'tailwind_format' => ['sometimes', 'string', 'max:100'],
             'icon' => ['sometimes', 'string', 'max:50'],

--- a/tests/Feature/SubjectManagementTest.php
+++ b/tests/Feature/SubjectManagementTest.php
@@ -152,3 +152,35 @@ test('invalid subject creation is rejected by validation', function () {
         'sort_order',
     ]);
 });
+
+test('admin can create subjects with same name in different courses', function () {
+    $admin = adminUserWithPermissions(['view admin', 'create subjects']);
+
+    Subject::create([
+        'name' => 'Physics',
+        'english_name' => 'Physics',
+        'slug' => 'hsc-physics',
+        'course' => 'hsc',
+        'tailwind_format' => 'bg-slate-500',
+        'icon' => 'book-open',
+        'sort_order' => 1,
+    ]);
+
+    $response = $this->actingAs($admin)->post('/admin/subjects', [
+        'name' => 'Physics',
+        'english_name' => 'Physics',
+        'course' => 'ssc',
+        'tailwind_format' => 'bg-slate-500',
+        'icon' => 'book-open',
+        'sort_order' => 1,
+    ]);
+
+    $response->assertRedirect();
+    $response->assertSessionHas('success', 'Subject created successfully.');
+
+    $this->assertDatabaseHas('subjects', [
+        'name' => 'Physics',
+        'course' => 'ssc',
+        'slug' => 'ssc-physics',
+    ]);
+});


### PR DESCRIPTION
## Summary
- Removed the `unique:subjects,name` validation rule from `StoreSubjectRequest` and `UpdateSubjectRequest`.
- Uniqueness is already guaranteed across courses by the `slug` field, which includes the course prefix.
- Added feature tests covering subject creation with identical names across `ssc` and `hsc` courses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Subjects can now share the same name across different courses.
  - Subject name validation continues to enforce required formatting and length rules.
  - Course-specific slugs remain unique and are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->