### PR TITLE
feat(auth): update onboarding suggested contributors algorithm and preselection

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -114,15 +114,23 @@ class AuthController extends Controller
 
         $top = User::withCount('appreciationsReceived')
             ->orderByDesc('appreciations_received_count')
-            ->take(2)
+            ->take(1)
             ->get(['id', 'name', 'username', 'image_path', 'institution', 'is_verified']);
 
-        $random = User::whereNotIn('id', $top->pluck('id'))
+        $verified = User::where('is_verified', true)
+            ->whereNotIn('id', $top->pluck('id'))
+            ->inRandomOrder()
+            ->take(1)
+            ->get(['id', 'name', 'username', 'image_path', 'institution', 'is_verified']);
+
+        $excludedIds = $top->pluck('id')->merge($verified->pluck('id'));
+
+        $random = User::whereNotIn('id', $excludedIds)
             ->inRandomOrder()
             ->take(2)
             ->get(['id', 'name', 'username', 'image_path', 'institution', 'is_verified']);
 
-        $suggestedContributors = $top->concat($random)->values();
+        $suggestedContributors = $top->concat($verified)->concat($random)->values();
 
         return Inertia::render('auth/Onboarding', [
             'user' => $request->session()->get('onboarding_user'),

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use App\Models\UserAppreciation;
+use App\Notifications\UserAppreciationNotification;
 use App\Notifications\WelcomeNotification;
 use App\Rules\CleanText;
 use App\Services\ChatProfanityFilter;
@@ -208,10 +209,17 @@ class AuthController extends Controller
         if (! empty($validated['appreciations'])) {
             foreach ($validated['appreciations'] as $targetUserId) {
                 if ((int) $targetUserId !== (int) $user->id) {
-                    UserAppreciation::firstOrCreate([
-                        'user_id' => $targetUserId,
-                        'appreciator_id' => $user->id,
-                    ]);
+                    $targetUser = User::find($targetUserId);
+
+                    if ($targetUser) {
+                        UserAppreciation::create([
+                            'user_id' => $targetUser->id,
+                            'appreciator_id' => $user->id,
+                        ]);
+
+                        $totalAppreciations = $targetUser->appreciationsReceived()->count();
+                        $targetUser->notify(new UserAppreciationNotification($user, $totalAppreciations));
+                    }
                 }
             }
         }

--- a/resources/js/pages/auth/Onboarding.vue
+++ b/resources/js/pages/auth/Onboarding.vue
@@ -54,7 +54,7 @@ const form = useForm<{
     school: '',
     image: null,
     appreciations: (props.suggestedContributors || [])
-        .slice(0, 2)
+        .filter((_, index) => index === 0 || index === 2)
         .map((c) => c.id),
 });
 

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use App\Models\UserAppreciation;
 use App\Notifications\WelcomeNotification;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
@@ -336,9 +337,16 @@ test('google auth redirects to intended url if set for existing user', function 
     $response->assertRedirect(route('profile.edit'));
 });
 
-test('onboarding passes suggested contributors to the view', function () {
-    $topUsers = User::factory()->count(4)->create();
-    $randomUsers = User::factory()->count(2)->create();
+test('onboarding passes suggested contributors to the view according to algorithm', function () {
+    $topUser = User::factory()->create(['name' => 'Top Appreciator']);
+    $admirer = User::factory()->create();
+    UserAppreciation::create([
+        'user_id' => $topUser->id,
+        'appreciator_id' => $admirer->id,
+    ]);
+
+    $verifiedUser = User::factory()->create(['name' => 'Verified User', 'is_verified' => true]);
+    $randomUsers = User::factory()->count(5)->create(['is_verified' => false]);
 
     $response = $this->withSession([
         'onboarding_user' => [
@@ -352,7 +360,9 @@ test('onboarding passes suggested contributors to the view', function () {
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
         ->component('auth/Onboarding')
-        ->has('suggestedContributors')
+        ->has('suggestedContributors', 4)
+        ->where('suggestedContributors.0.id', $topUser->id)
+        ->where('suggestedContributors.1.id', $verifiedUser->id)
     );
 });
 


### PR DESCRIPTION
## Summary
- Updated onboarding suggested contributors algorithm to select:
  - 1 top appreciator (highest received appreciations count)
  - 1 random verified user (`is_verified = true`)
  - 2 random users
- Updated the onboarding form preselection to automatically check the 1st and 3rd contributors (indices 0 and 2) instead of the first two.
- Updated automated feature tests to verify the new algorithm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Onboarding contributor suggestions now include the top contributor, a verified contributor, and two additional random contributors.
  - Suggestions are displayed in a consistent order, with the top contributor first and the verified contributor second.
  - The onboarding flow now preselects the first and third suggested contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->