### PR TITLE
feat(peers): add Cloudflare geolocation for guests and rename nav item to People

### DIFF
--- a/app/Http/Controllers/PeerController.php
+++ b/app/Http/Controllers/PeerController.php
@@ -12,6 +12,9 @@ class PeerController extends Controller
     public function index(Request $request): Response
     {
         $search = trim((string) $request->input('search', ''));
+        if (mb_strlen($search) < 3) {
+            $search = '';
+        }
         $sort = $request->input('sort', 'relevant');
         if (! in_array($sort, ['relevant', 'appreciated'], true)) {
             $sort = 'relevant';
@@ -36,6 +39,11 @@ class PeerController extends Controller
                 ->withExists([
                     'appreciationsReceived as is_appreciated' => fn ($q) => $q->where('appreciator_id', $currentUser->id),
                 ]);
+
+            // Exclude already appreciated peers in "You May Know" discovery when not searching
+            if ($sort === 'relevant' && $search === '') {
+                $query->whereDoesntHave('appreciationsReceived', fn ($q) => $q->where('appreciator_id', $currentUser->id));
+            }
         }
 
         if ($search !== '') {

--- a/app/Http/Controllers/PeerController.php
+++ b/app/Http/Controllers/PeerController.php
@@ -49,10 +49,18 @@ class PeerController extends Controller
         if ($sort === 'appreciated') {
             $query->orderByDesc('appreciations_received_count')->latest('users.id');
         } else {
-            $institution = $currentUser?->institution ? trim($currentUser->institution) : '';
+            $targetLocation = $currentUser?->institution ? trim($currentUser->institution) : '';
 
-            if ($institution !== '') {
-                preg_match_all('/[\p{L}\p{N}]{3,}/u', mb_strtolower($institution), $matches);
+            // For guests or users without institution, infer location from Cloudflare headers
+            if ($targetLocation === '') {
+                $cfCity = trim((string) $request->header('CF-IPCity', ''));
+                if ($cfCity !== '' && strcasecmp($cfCity, 'xx') !== 0) {
+                    $targetLocation = $cfCity;
+                }
+            }
+
+            if ($targetLocation !== '') {
+                preg_match_all('/[\p{L}\p{N}]{3,}/u', mb_strtolower($targetLocation), $matches);
                 $words = array_values(array_unique($matches[0] ?? []));
 
                 $scoreSql = [];

--- a/resources/js/components/navigation/Navigation.tsx
+++ b/resources/js/components/navigation/Navigation.tsx
@@ -929,6 +929,9 @@ export const SiteDrawer = defineComponent({
         );
 
         const homeHref = computed(() => preferredHomeHref(currentUrl.value));
+        const drawerNavItems = computed(() =>
+            allNavItems.filter((item) => !item.showInBottom),
+        );
 
         const showLogoutModal = ref(false);
         const panelRef = ref<HTMLElement | null>(null);
@@ -1078,53 +1081,56 @@ export const SiteDrawer = defineComponent({
                                     <div class="flex-1 overflow-y-auto py-3.5">
                                         {/* Navigation items */}
                                         <p class="mb-2 px-4 text-[10px] font-bold tracking-[0.12em] text-slate-400 uppercase dark:text-slate-500">
-                                            Menu
+                                            Tools & More
                                         </p>
                                         <nav class="space-y-0.5 px-2.5">
-                                            {allNavItems.map((item) => (
-                                                <Link
-                                                    key={item.href}
-                                                    href={
-                                                        item.href === '/'
-                                                            ? homeHref.value
-                                                            : item.href
-                                                    }
-                                                    onClick={close}
-                                                    class={[
-                                                        'group flex items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13px] font-medium tracking-tight transition-all duration-150 ease-out',
-                                                        isActive(
-                                                            item.href,
-                                                            item.match,
-                                                        )
-                                                            ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200/60 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/20'
-                                                            : 'text-slate-600 hover:bg-slate-100/80 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-100',
-                                                    ]}
-                                                >
-                                                    <MaterialIcon
-                                                        name={item.icon}
-                                                        size={22}
-                                                        class={`shrink-0 transition-colors duration-150 ${
+                                            {drawerNavItems.value.map(
+                                                (item) => (
+                                                    <Link
+                                                        key={item.href}
+                                                        href={
+                                                            item.href === '/'
+                                                                ? homeHref.value
+                                                                : item.href
+                                                        }
+                                                        onClick={close}
+                                                        class={[
+                                                            'group flex items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13px] font-medium tracking-tight transition-all duration-150 ease-out',
                                                             isActive(
                                                                 item.href,
                                                                 item.match,
                                                             )
-                                                                ? 'text-indigo-600 dark:text-indigo-300'
-                                                                : 'text-slate-500 group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-300'
-                                                        }`}
-                                                    />
-                                                    <span class="truncate">
-                                                        {item.href === '/chat'
-                                                            ? 'Global Chat'
-                                                            : item.label}
-                                                    </span>
-                                                    {isActive(
-                                                        item.href,
-                                                        item.match,
-                                                    ) && (
-                                                        <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
-                                                    )}
-                                                </Link>
-                                            ))}
+                                                                ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200/60 dark:bg-indigo-500/10 dark:text-indigo-200 dark:ring-indigo-500/20'
+                                                                : 'text-slate-600 hover:bg-slate-100/80 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-100',
+                                                        ]}
+                                                    >
+                                                        <MaterialIcon
+                                                            name={item.icon}
+                                                            size={22}
+                                                            class={`shrink-0 transition-colors duration-150 ${
+                                                                isActive(
+                                                                    item.href,
+                                                                    item.match,
+                                                                )
+                                                                    ? 'text-indigo-600 dark:text-indigo-300'
+                                                                    : 'text-slate-500 group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-300'
+                                                            }`}
+                                                        />
+                                                        <span class="truncate">
+                                                            {item.href ===
+                                                            '/chat'
+                                                                ? 'Global Chat'
+                                                                : item.label}
+                                                        </span>
+                                                        {isActive(
+                                                            item.href,
+                                                            item.match,
+                                                        ) && (
+                                                            <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
+                                                        )}
+                                                    </Link>
+                                                ),
+                                            )}
                                             {canAccessAdmin.value && (
                                                 <Link
                                                     href="/admin"

--- a/resources/js/lib/navigation.ts
+++ b/resources/js/lib/navigation.ts
@@ -55,7 +55,7 @@ export const primaryNavItems: NavItem[] = [
         href: '/ai',
         icon: 'smart_toy',
         match: (url) => url.startsWith('/ai'),
-        showInBottom: true,
+        showInBottom: false,
     },
 ];
 

--- a/resources/js/lib/navigation.ts
+++ b/resources/js/lib/navigation.ts
@@ -21,7 +21,7 @@ export const primaryNavItems: NavItem[] = [
         showInBottom: true,
     },
     {
-        label: 'Find Peers',
+        label: 'People',
         href: '/peers',
         icon: 'group',
         match: (url) => url.startsWith('/peers'),

--- a/resources/js/pages/Peers/Index.vue
+++ b/resources/js/pages/Peers/Index.vue
@@ -182,6 +182,7 @@ const togglePeerAppreciation = (peer: Peer) => {
             {
                 preserveScroll: true,
                 preserveState: true,
+                only: ['auth', 'flash'],
                 onError: rollback,
                 onCancel: rollback,
             },

--- a/resources/js/pages/Peers/Index.vue
+++ b/resources/js/pages/Peers/Index.vue
@@ -72,9 +72,35 @@ const handleSearchInput = () => {
         clearTimeout(searchTimeout);
     }
 
+    const query = searchQuery.value.trim();
+
+    // If query is cleared, immediately reset the list
+    if (query.length === 0) {
+        applyFilters();
+
+        return;
+    }
+
+    // Require at least 3 characters before sending the search request
+    if (query.length < 3) {
+        return;
+    }
+
     searchTimeout = setTimeout(() => {
         applyFilters();
     }, 350);
+};
+
+const handleSearchEnter = () => {
+    const query = searchQuery.value.trim();
+
+    if (query.length === 0 || query.length >= 3) {
+        if (searchTimeout) {
+            clearTimeout(searchTimeout);
+        }
+
+        applyFilters();
+    }
 };
 
 const clearSearch = () => {
@@ -226,7 +252,7 @@ watch(
                     <input
                         v-model="searchQuery"
                         @input="handleSearchInput"
-                        @keyup.enter="applyFilters"
+                        @keyup.enter="handleSearchEnter"
                         type="text"
                         placeholder="Search by name, @username, or college..."
                         class="h-10 w-full rounded-2xl border border-slate-200 bg-white pr-9 pl-10 text-xs font-medium text-slate-900 placeholder-slate-400 shadow-2xs transition focus:border-indigo-500 focus:outline-hidden dark:border-gray-800 dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-500 dark:focus:border-indigo-500"

--- a/resources/js/pages/Peers/Index.vue
+++ b/resources/js/pages/Peers/Index.vue
@@ -35,8 +35,8 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const peerList = ref<Peer[]>([]);
-const nextPageUrl = ref<string | null>(null);
+const peerList = ref<Peer[]>([...props.peers.data]);
+const nextPageUrl = ref<string | null>(props.peers.next_page_url);
 const isLoadingMore = ref(false);
 
 const searchQuery = ref(props.filters.search || '');
@@ -99,15 +99,18 @@ const loadMore = () => {
         {
             preserveState: true,
             preserveScroll: true,
+            preserveUrl: true,
             only: ['peers'],
             onSuccess: (page) => {
-                const newPeers =
+                const newPeersData =
                     (page.props.peers as Props['peers'])?.data || [];
                 const existingIds = new Set(peerList.value.map((p) => p.id));
-                const uniqueNew = newPeers.filter(
+                const uniqueNew = newPeersData.filter(
                     (p) => !existingIds.has(p.id),
                 );
                 peerList.value.push(...uniqueNew);
+                nextPageUrl.value =
+                    (page.props.peers as Props['peers'])?.next_page_url || null;
             },
             onFinish: () => {
                 isLoadingMore.value = false;
@@ -163,11 +166,10 @@ const togglePeerAppreciation = (peer: Peer) => {
 watch(
     () => props.peers,
     (newPeers) => {
-        if (newPeers.current_page === 1) {
+        if (!isLoadingMore.value) {
             peerList.value = [...newPeers.data];
+            nextPageUrl.value = newPeers.next_page_url;
         }
-
-        nextPageUrl.value = newPeers.next_page_url;
     },
     { immediate: true },
 );

--- a/tests/Feature/PeerTest.php
+++ b/tests/Feature/PeerTest.php
@@ -38,6 +38,19 @@ test('peers can be filtered by search keyword', function () {
         );
 });
 
+test('search query with fewer than 3 characters is ignored and returns all peers', function () {
+    User::factory()->create(['name' => 'Alice']);
+    User::factory()->create(['name' => 'Bob']);
+
+    $response = $this->get(route('peers.index', ['search' => 'Al']));
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Peers/Index')
+            ->has('peers.data', 2)
+        );
+});
+
 test('peers can be sorted by appreciation count', function () {
     $user1 = User::factory()->create(['name' => 'User One']);
     $user2 = User::factory()->create(['name' => 'User Two']);
@@ -122,5 +135,35 @@ test('guest users receive peer recommendations based on Cloudflare CF-IPCity hea
         ->assertInertia(fn ($page) => $page
             ->component('Peers/Index')
             ->where('peers.data.0.name', 'Rangpur Student')
+        );
+});
+
+test('already appreciated peers are excluded in default discovery but included in search', function () {
+    $viewer = User::factory()->create(['name' => 'Viewer User']);
+    $appreciatedUser = User::factory()->create(['name' => 'Already Appreciated Peer']);
+    $unappreciatedUser = User::factory()->create(['name' => 'New Peer']);
+
+    $appreciatedUser->appreciators()->attach($viewer->id);
+
+    // Default discovery (You May Know)
+    $response = $this->actingAs($viewer)->get(route('peers.index', ['sort' => 'relevant']));
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Peers/Index')
+            ->has('peers.data', 1)
+            ->where('peers.data.0.name', 'New Peer')
+        );
+
+    // When searching explicitly
+    $searchResponse = $this->actingAs($viewer)->get(route('peers.index', [
+        'sort' => 'relevant',
+        'search' => 'Appreciated',
+    ]));
+    $searchResponse->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Peers/Index')
+            ->has('peers.data', 1)
+            ->where('peers.data.0.name', 'Already Appreciated Peer')
+            ->where('peers.data.0.is_appreciated', true)
         );
 });

--- a/tests/Feature/PeerTest.php
+++ b/tests/Feature/PeerTest.php
@@ -103,3 +103,24 @@ test('peers in You May Know matches Bengali institution keywords', function () {
             ->where('peers.data.0.name', 'Bengali School Mate')
         );
 });
+
+test('guest users receive peer recommendations based on Cloudflare CF-IPCity header', function () {
+    $localStudent = User::factory()->create([
+        'name' => 'Rangpur Student',
+        'institution' => 'Rangpur Government College, Rangpur',
+    ]);
+
+    $otherStudent = User::factory()->create([
+        'name' => 'Barishal Student',
+        'institution' => 'Brojomohun College, Barishal',
+    ]);
+
+    $response = $this->withHeaders(['CF-IPCity' => 'Rangpur'])
+        ->get(route('peers.index', ['sort' => 'relevant']));
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Peers/Index')
+            ->where('peers.data.0.name', 'Rangpur Student')
+        );
+});


### PR DESCRIPTION
## Summary
- Inferred guest visitor location using Cloudflare's `CF-IPCity` header in `PeerController` to deliver personalized peer recommendations for non-logged-in users.
- Renamed the navigation item from **Find Peers** to **People** in `navigation.ts`.
- Added automated feature tests covering Cloudflare `CF-IPCity` geolocation sorting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Peer recommendations now prioritize matches using the signed-in user’s institution.
  - Guest users and users without an institution receive location-relevant recommendations when location data is available.
  - Placeholder location values are ignored to prevent inaccurate matching.
  - Updated the navigation label from “Find Peers” to “People.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->