### PR TITLE
feat(ui): profile institution display, image viewer click-to-close, chat platform links, and peer list fixes

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,6 +38,7 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'name' => config('app.name'),
+            'app_url' => config('app.url'),
             'app_version' => config('app.version'),
             'auth' => [
                 'user' => $request->user(),

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,7 +38,6 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'name' => config('app.name'),
-            'app_url' => config('app.url'),
             'app_version' => config('app.version'),
             'auth' => [
                 'user' => $request->user(),

--- a/resources/js/components/ImageViewerModal.vue
+++ b/resources/js/components/ImageViewerModal.vue
@@ -1,28 +1,26 @@
 <script setup lang="ts">
-import { Download, Minimize2, RotateCcw } from 'lucide-vue-next';
+import { Minimize2, RotateCcw } from 'lucide-vue-next';
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
 const modelValue = defineModel<boolean>({ default: false });
 
-const props = withDefaults(
+withDefaults(
     defineProps<{
         src: string;
         alt?: string;
         title?: string;
-        showDownload?: boolean;
     }>(),
     {
         alt: 'Attached Image',
         title: '',
-        showDownload: true,
     },
 );
 
 const emit = defineEmits<{
-    (e: 'download'): void;
     (e: 'close'): void;
 }>();
 
+const backdropRef = ref<HTMLElement | null>(null);
 const scale = ref(1);
 const translateX = ref(0);
 const translateY = ref(0);
@@ -30,6 +28,9 @@ const isDragging = ref(false);
 
 let startX = 0;
 let startY = 0;
+let pointerDownScreenX = 0;
+let pointerDownScreenY = 0;
+let hasMoved = false;
 let initialScale = 1;
 let startTouchDistance = 0;
 
@@ -62,8 +63,12 @@ const handlePointerDown = (e: MouseEvent | TouchEvent) => {
     }
 
     isDragging.value = true;
+    hasMoved = false;
     const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
     const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+
+    pointerDownScreenX = clientX;
+    pointerDownScreenY = clientY;
 
     startX = clientX - translateX.value;
     startY = clientY - translateY.value;
@@ -83,14 +88,25 @@ const handlePointerMove = (e: MouseEvent | TouchEvent) => {
         return;
     }
 
-    if (!isDragging.value || scale.value === 1) {
+    if (!isDragging.value) {
+        return;
+    }
+
+    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+    const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+
+    if (
+        Math.hypot(clientX - pointerDownScreenX, clientY - pointerDownScreenY) >
+        5
+    ) {
+        hasMoved = true;
+    }
+
+    if (scale.value === 1) {
         return;
     }
 
     e.preventDefault();
-
-    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
-    const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
 
     translateX.value = clientX - startX;
     translateY.value = clientY - startY;
@@ -104,6 +120,16 @@ const handlePointerUp = () => {
     }
 };
 
+const handleBackdropClick = (e: MouseEvent) => {
+    if (hasMoved) {
+        return;
+    }
+
+    if (e.target === backdropRef.value) {
+        close();
+    }
+};
+
 const handleWheel = (e: WheelEvent) => {
     e.preventDefault();
     const zoomIntensity = 0.1;
@@ -113,24 +139,6 @@ const handleWheel = (e: WheelEvent) => {
 
     if (scale.value === 1) {
         resetZoom();
-    }
-};
-
-const handleDownload = () => {
-    emit('download');
-
-    if (props.src) {
-        const downloadUrl = props.src.includes('?')
-            ? `${props.src}&download=1`
-            : `${props.src}?download=1`;
-
-        const link = document.createElement('a');
-        link.href = downloadUrl;
-        link.download = props.title || props.alt || 'download';
-        link.target = '_blank';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
     }
 };
 
@@ -181,7 +189,9 @@ onBeforeUnmount(() => {
         >
             <div
                 v-if="modelValue"
-                class="fixed inset-0 z-[120] flex touch-none items-center justify-center bg-slate-950/95 backdrop-blur-sm select-none"
+                ref="backdropRef"
+                class="fixed inset-0 z-[120] flex cursor-zoom-out touch-none items-center justify-center bg-slate-950/95 backdrop-blur-sm select-none"
+                @click="handleBackdropClick"
                 @wheel="handleWheel"
                 @mousedown="handlePointerDown"
                 @mousemove="handlePointerMove"
@@ -203,18 +213,6 @@ onBeforeUnmount(() => {
                         <span class="text-slate-500">•</span>
                         <span>Drag to Pan</span>
                     </div>
-
-                    <!-- Download Button -->
-                    <button
-                        v-if="showDownload && src"
-                        @click.stop="handleDownload"
-                        type="button"
-                        class="cursor-pointer rounded-full bg-white/10 p-3 text-white backdrop-blur-md transition-all hover:bg-white/20 active:scale-95 dark:bg-gray-900/10 dark:hover:bg-gray-900/20"
-                        title="Download Image"
-                        aria-label="Download Image"
-                    >
-                        <Download class="h-5 w-5" />
-                    </button>
 
                     <!-- Reset Zoom Button -->
                     <button
@@ -244,10 +242,12 @@ onBeforeUnmount(() => {
                 <img
                     :src="src"
                     :alt="alt || title"
-                    class="pointer-events-none max-h-[90vh] max-w-[90vw] rounded object-contain shadow-2xl transition-transform duration-75 ease-out"
+                    class="pointer-events-auto max-h-[90vh] max-w-[90vw] cursor-default rounded object-contain shadow-2xl transition-transform duration-75 ease-out"
+                    :class="{ 'cursor-grab active:cursor-grabbing': scale > 1 }"
                     :style="{
                         transform: `translate(${translateX}px, ${translateY}px) scale(${scale})`,
                     }"
+                    @click.stop
                 />
             </div>
         </Transition>

--- a/resources/js/pages/Chat/Index.vue
+++ b/resources/js/pages/Chat/Index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Head, Link, router, usePage } from '@inertiajs/vue3';
+import { Head, Link, router } from '@inertiajs/vue3';
 import {
     Send,
     Trash2,
@@ -1191,8 +1191,6 @@ const submitReport = async () => {
     }
 };
 
-const page = usePage();
-
 const isPlatformUrl = (urlString: string): boolean => {
     if (urlString.startsWith('/')) {
         return true;
@@ -1212,11 +1210,11 @@ const isPlatformUrl = (urlString: string): boolean => {
             }
         }
 
-        const appUrl = (page?.props as Record<string, any>)?.app_url;
+        const envAppUrl = import.meta.env.VITE_APP_URL;
 
-        if (appUrl) {
+        if (envAppUrl) {
             try {
-                const appParsed = new URL(appUrl);
+                const appParsed = new URL(envAppUrl);
                 validHosts.add(appParsed.hostname.toLowerCase());
                 validHosts.add(appParsed.host.toLowerCase());
             } catch {

--- a/resources/js/pages/Chat/Index.vue
+++ b/resources/js/pages/Chat/Index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Head, Link, router } from '@inertiajs/vue3';
+import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import {
     Send,
     Trash2,
@@ -76,9 +76,10 @@ interface ChatMessageItem {
 }
 
 interface MessageSegment {
-    type: 'text' | 'mention';
+    type: 'text' | 'mention' | 'link';
     text: string;
     username?: string;
+    url?: string;
 }
 
 const props = defineProps<{
@@ -1190,17 +1191,63 @@ const submitReport = async () => {
     }
 };
 
+const page = usePage();
+
+const isPlatformUrl = (urlString: string): boolean => {
+    if (urlString.startsWith('/')) {
+        return true;
+    }
+
+    try {
+        const parsed = new URL(urlString);
+        const validHosts = new Set<string>();
+
+        if (typeof window !== 'undefined') {
+            if (window.location.hostname) {
+                validHosts.add(window.location.hostname.toLowerCase());
+            }
+
+            if (window.location.host) {
+                validHosts.add(window.location.host.toLowerCase());
+            }
+        }
+
+        const appUrl = (page?.props as Record<string, any>)?.app_url;
+
+        if (appUrl) {
+            try {
+                const appParsed = new URL(appUrl);
+                validHosts.add(appParsed.hostname.toLowerCase());
+                validHosts.add(appParsed.host.toLowerCase());
+            } catch {
+                // ignore
+            }
+        }
+
+        validHosts.add('hscstack.com');
+        validHosts.add('www.hscstack.com');
+
+        return (
+            validHosts.has(parsed.hostname.toLowerCase()) ||
+            validHosts.has(parsed.host.toLowerCase())
+        );
+    } catch {
+        return false;
+    }
+};
+
 const parseMessageSegments = (content: string): MessageSegment[] => {
     if (!content) {
         return [];
     }
 
-    const mentionRegex = /(?<=^|\s)@([a-zA-Z0-9_.-]+)/g;
+    const tokenRegex =
+        /(https?:\/\/[^\s<>"'()]+|(?<=^|\s)\/(?:forum|u|resource|peers|chat|blogs|p|feed|about|terms|privacy|guidelines|contact)(?:\/[^\s<>"'()]*)?|(?<=^|\s)@([a-zA-Z0-9_.-]+))/gi;
     const segments: MessageSegment[] = [];
     let lastIndex = 0;
     let match: RegExpExecArray | null;
 
-    while ((match = mentionRegex.exec(content)) !== null) {
+    while ((match = tokenRegex.exec(content)) !== null) {
         const matchStart = match.index;
 
         if (matchStart > lastIndex) {
@@ -1210,28 +1257,41 @@ const parseMessageSegments = (content: string): MessageSegment[] => {
             });
         }
 
-        let username = match[1];
-        let mentionText = match[0];
+        let rawText = match[0];
         let trailingPunctuation = '';
 
-        const trailingMatch = username.match(/[.,!?;:]+$/);
+        const trailingMatch = rawText.match(/[.,!?;:]+$/);
 
         if (trailingMatch) {
             trailingPunctuation = trailingMatch[0];
-            username = username.slice(0, -trailingPunctuation.length);
-            mentionText = mentionText.slice(0, -trailingPunctuation.length);
+            rawText = rawText.slice(0, -trailingPunctuation.length);
         }
 
-        if (username) {
+        if (rawText.startsWith('@')) {
+            const username = rawText.slice(1);
+
+            if (username) {
+                segments.push({
+                    type: 'mention',
+                    text: rawText,
+                    username,
+                });
+            } else {
+                segments.push({
+                    type: 'text',
+                    text: rawText,
+                });
+            }
+        } else if (rawText && isPlatformUrl(rawText)) {
             segments.push({
-                type: 'mention',
-                text: mentionText,
-                username,
+                type: 'link',
+                text: rawText,
+                url: rawText,
             });
-        } else {
+        } else if (rawText) {
             segments.push({
                 type: 'text',
-                text: match[0],
+                text: rawText,
             });
         }
 
@@ -1680,6 +1740,18 @@ onUnmounted(() => {
                                     >
                                         {{ seg.text }}
                                     </Link>
+                                    <a
+                                        v-else-if="
+                                            seg.type === 'link' && seg.url
+                                        "
+                                        :href="seg.url"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="font-medium break-all text-indigo-600 underline underline-offset-2 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+                                        @click.stop
+                                    >
+                                        {{ seg.text }}
+                                    </a>
                                     <span v-else>{{ seg.text }}</span>
                                 </template>
                             </p>

--- a/resources/js/pages/Peers/Index.vue
+++ b/resources/js/pages/Peers/Index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Head, Link, router, useRemember } from '@inertiajs/vue3';
+import { Head, Link, router } from '@inertiajs/vue3';
 import { Search, X, Users, Heart, Loader2 } from 'lucide-vue-next';
 import { onUnmounted, ref, watch } from 'vue';
 import EmptyState from '@/components/EmptyState.vue';
@@ -35,15 +35,31 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const peerList = useRemember<Peer[]>([...props.peers.data], 'Peers/peerList');
-const nextPageUrl = useRemember<string | null>(
-    props.peers.next_page_url,
-    'Peers/nextPageUrl',
-);
+const peerList = ref<Peer[]>([...props.peers.data]);
+const nextPageUrl = ref<string | null>(props.peers.next_page_url);
 const isLoadingMore = ref(false);
 
 const searchQuery = ref(props.filters.search || '');
 const currentSort = ref(props.filters.sort || 'relevant');
+
+watch(
+    () => props.peers,
+    (newPeers) => {
+        if (!isLoadingMore.value) {
+            peerList.value = [...(newPeers?.data || [])];
+            nextPageUrl.value = newPeers?.next_page_url || null;
+        }
+    },
+);
+
+watch(
+    () => props.filters,
+    (newFilters) => {
+        searchQuery.value = newFilters?.search || '';
+        currentSort.value = newFilters?.sort || 'relevant';
+    },
+    { deep: true },
+);
 
 const sortOptions = [
     { value: 'relevant', label: 'You May Know' },

--- a/resources/js/pages/User/Show.vue
+++ b/resources/js/pages/User/Show.vue
@@ -403,12 +403,12 @@ const timeAgo = formatTimeAgo;
                             <!-- Academic / Institution Info -->
                             <div
                                 v-if="profileUser.institution"
-                                class="flex items-center gap-1.5 text-xs font-medium text-slate-600 dark:text-gray-300"
+                                class="flex items-start gap-1.5 pt-0.5 text-xs font-medium text-slate-600 dark:text-gray-300"
                             >
                                 <GraduationCap
-                                    class="h-3.5 w-3.5 shrink-0 text-slate-400 dark:text-gray-500"
+                                    class="mt-0.5 h-3.5 w-3.5 shrink-0 text-slate-400 dark:text-gray-500"
                                 />
-                                <span class="truncate">{{
+                                <span class="leading-snug break-words">{{
                                     profileUser.institution
                                 }}</span>
                             </div>


### PR DESCRIPTION
## Summary
- **Chat Platform Links**: Auto-linked platform URLs and relative paths in `resources/js/pages/Chat/Index.vue` opening in a new tab, detecting platform origins directly via client-side `window.location` and `import.meta.env`.
- **Image Viewer Modal**: Removed download button and added backdrop click-to-close support on empty space in `resources/js/components/ImageViewerModal.vue`.
- **Profile Header**: Wrapped full institution name without truncation in `resources/js/pages/User/Show.vue`.
- **Peer List State**: Removed `useRemember` from `resources/js/pages/Peers/Index.vue` and simplified to reactive `ref` with props watchers so search and sort never blank out or conflict with browser history.