### PR TITLE
fix(auth): handle cross-subdomain redirect with Inertia location during onboarding

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -233,7 +233,16 @@ class AuthController extends Controller
             ? route('user.profile', $user->username)
             : route('profile.edit');
 
-        return redirect()->intended($defaultUrl)->with('success', 'Account created successfully! Welcome to HSCStack.');
+        $targetUrl = $request->session()->pull('url.intended', $defaultUrl);
+
+        $targetHost = parse_url($targetUrl, PHP_URL_HOST);
+        $appHost = parse_url(config('app.url'), PHP_URL_HOST);
+
+        if ($targetHost && $appHost && $targetHost !== $appHost) {
+            return Inertia::location($targetUrl);
+        }
+
+        return redirect()->to($targetUrl)->with('success', 'Account created successfully! Welcome to HSCStack.');
     }
 
     private function downloadGoogleAvatar(?string $avatarUrl): ?string

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -236,6 +236,34 @@ test('redirects to custom redirect url after onboarding for new user', function 
     $onboardResponse->assertRedirect(url('/ai'));
 });
 
+test('redirects to trusted subdomain after onboarding for new user', function () {
+    config(['app.url' => 'https://hscstack.site']);
+    $subdomainUrl = 'https://ssc2026.hscstack.site';
+
+    $this->get('/auth/google?redirect='.urlencode($subdomainUrl));
+
+    $abstractUser = Mockery::mock(Laravel\Socialite\Two\User::class);
+    $abstractUser->shouldReceive('getId')->andReturn('google-id-new-subdomain');
+    $abstractUser->shouldReceive('getEmail')->andReturn('new-subdomain@example.com');
+    $abstractUser->shouldReceive('getName')->andReturn('New Subdomain User');
+    $abstractUser->shouldReceive('getNickname')->andReturn('newsubdomain');
+    $abstractUser->shouldReceive('getAvatar')->andReturn(null);
+
+    Socialite::shouldReceive('driver->user')->andReturn($abstractUser);
+
+    $callbackResponse = $this->get(route('auth.google.callback'));
+    $callbackResponse->assertRedirect(route('onboarding'));
+
+    $onboardResponse = $this->withHeaders(['X-Inertia' => 'true'])->post(route('onboarding.complete'), [
+        'name' => 'New Subdomain User',
+        'username' => 'new_subdomain_user',
+        'school' => 'Rajshahi College',
+    ]);
+
+    $onboardResponse->assertStatus(409);
+    $onboardResponse->assertHeader('X-Inertia-Location', $subdomainUrl);
+});
+
 test('redirects to custom redirect url after authentication for existing user', function () {
     $user = User::factory()->create([
         'email' => 'redirect-test@example.com',


### PR DESCRIPTION
## Description
Fixes an issue where new users creating an account via the onboarding flow were failing to redirect to external/trusted subdomains (e.g., `ssc26-dinajpur.hscstack.site`).

### Changes
- Updated `completeOnboarding` in `AuthController` to detect when the intended target host differs from `config('app.url')` and return `Inertia::location($targetUrl)` instead of a standard 302 redirect.
- Added automated feature tests in `AuthenticationTest` verifying the `X-Inertia-Location` header response on cross-host redirection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-onboarding redirects by safely handling saved destination URLs.
  * Same-site destinations now redirect normally with a success message.
  * Trusted external or subdomain destinations now navigate correctly through the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->