### PR TITLE
feat(profile): allow clearing and removing avatar photo

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -21,7 +21,13 @@ class ProfileController extends Controller
         $user = $request->user();
         $validated = $request->validated();
 
-        if ($request->hasFile('file')) {
+        if ($request->boolean('clear_image')) {
+            if ($user->image_path) {
+                Storage::delete($user->image_path);
+            }
+
+            $validated['image_path'] = null;
+        } elseif ($request->hasFile('file')) {
             $path = $request->file('file')->store('users/profile-images');
 
             if ($user->image_path) {

--- a/app/Http/Requests/Profile/UpdateProfileRequest.php
+++ b/app/Http/Requests/Profile/UpdateProfileRequest.php
@@ -36,6 +36,7 @@ class UpdateProfileRequest extends FormRequest
                 new CleanText,
             ],
             'file' => ['sometimes', 'nullable', 'image', 'mimes:jpg,jpeg,png,webp', 'max:5120'],
+            'clear_image' => ['sometimes', 'boolean'],
             'about' => ['sometimes', 'nullable', 'string', 'max:1000', new CleanText],
             'institution' => ['sometimes', 'nullable', 'string', 'max:255', new CleanText],
             'activity_privacy' => ['sometimes', 'string', Rule::in(['public', 'appreciators_only', 'private'])],

--- a/resources/js/pages/Profile.vue
+++ b/resources/js/pages/Profile.vue
@@ -33,12 +33,15 @@ const isUnverified = computed(() => {
 const showAdvancedSettings = ref(false);
 const showConfirmModal = ref(false);
 const isCompressingAvatar = ref(false);
+const avatarPreview = ref<string | null>(null);
+const fileInputRef = ref<HTMLInputElement | null>(null);
 
 const form = useForm({
     _method: 'PUT',
     name: user.value?.name || '',
     username: user.value?.username || '',
     file: null as File | null,
+    clear_image: false,
     about: user.value?.about || '',
     institution: user.value?.institution || '',
     activity_privacy: user.value?.activity_privacy || 'public',
@@ -85,9 +88,34 @@ const handleAvatarSelect = async (event: Event) => {
             }
 
             form.file = resultFile;
+            form.clear_image = false;
+
+            if (avatarPreview.value) {
+                URL.revokeObjectURL(avatarPreview.value);
+            }
+
+            avatarPreview.value = URL.createObjectURL(resultFile);
         } finally {
             isCompressingAvatar.value = false;
         }
+    }
+};
+
+const handleRemoveAvatar = () => {
+    form.file = null;
+    form.errors.file = '';
+
+    if (avatarPreview.value) {
+        URL.revokeObjectURL(avatarPreview.value);
+        avatarPreview.value = null;
+    }
+
+    if (fileInputRef.value) {
+        fileInputRef.value.value = '';
+    }
+
+    if (user.value?.image_url) {
+        form.clear_image = true;
     }
 };
 
@@ -376,8 +404,12 @@ const submitForm = () => {
                 <div class="flex flex-col gap-6 sm:flex-row sm:items-center">
                     <div class="relative shrink-0">
                         <img
-                            v-if="user?.image_url && !isCompressingAvatar"
-                            :src="user.image_url"
+                            v-if="
+                                (avatarPreview ||
+                                    (user?.image_url && !form.clear_image)) &&
+                                !isCompressingAvatar
+                            "
+                            :src="avatarPreview || user.image_url"
                             :alt="user.name"
                             class="h-20 w-20 rounded-full border-2 border-slate-200 object-cover shadow-xs dark:border-gray-700"
                         />
@@ -398,13 +430,34 @@ const submitForm = () => {
                     </div>
 
                     <div class="flex-1">
-                        <label
-                            for="file"
-                            class="mb-1.5 block text-xs font-semibold text-slate-700 dark:text-gray-300"
-                        >
-                            Upload New Photo
-                        </label>
+                        <div class="mb-1.5 flex items-center justify-between">
+                            <label
+                                for="file"
+                                class="block text-xs font-semibold text-slate-700 dark:text-gray-300"
+                            >
+                                Upload New Photo
+                            </label>
+                            <button
+                                v-if="
+                                    (user?.image_url && !form.clear_image) ||
+                                    form.file
+                                "
+                                type="button"
+                                @click="handleRemoveAvatar"
+                                :disabled="
+                                    form.processing || isCompressingAvatar
+                                "
+                                class="cursor-pointer text-xs font-semibold text-rose-600 hover:text-rose-700 hover:underline disabled:opacity-50 dark:text-rose-400 dark:hover:text-rose-300"
+                            >
+                                {{
+                                    form.file && !user?.image_url
+                                        ? 'Clear Selected'
+                                        : 'Remove Photo'
+                                }}
+                            </button>
+                        </div>
                         <input
+                            ref="fileInputRef"
                             type="file"
                             id="file"
                             accept="image/jpeg,image/png,image/webp"
@@ -422,7 +475,9 @@ const submitForm = () => {
                             {{
                                 isCompressingAvatar
                                     ? 'Optimizing avatar...'
-                                    : 'Supports PNG, JPG, or WEBP up to 5MB (auto-optimized).'
+                                    : form.clear_image
+                                      ? 'Photo will be removed upon saving.'
+                                      : 'Supports PNG, JPG, or WEBP up to 5MB (auto-optimized).'
                             }}
                         </p>
                         <p


### PR DESCRIPTION
## Description
This PR adds support for users to clear or remove their profile picture on the Profile page.

### Summary of Changes:
- **Frontend ([Profile.vue](file:///home/tajim/Projects/platform/resources/js/pages/Profile.vue))**: Added a clean 'Remove Photo' / 'Clear Selected' button and instant preview.
- **Backend ([ProfileController.php](file:///home/tajim/Projects/platform/app/Http/Controllers/ProfileController.php) & [UpdateProfileRequest.php](file:///home/tajim/Projects/platform/app/Http/Requests/Profile/UpdateProfileRequest.php))**: Added validation and handling for the `clear_image` flag to remove the avatar file from storage and set `image_path` to `null` in the database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live previews when selecting a new profile photo.
  - Added options to remove an existing photo or clear a newly selected photo before saving.
  - Added a notice indicating when the current photo will be removed upon saving.
  - Profile photo removal is now saved correctly, including deleting the stored image and clearing the profile image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->