### PR TITLE
fix: prevent auto-downloading Google avatars for existing users

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -72,7 +72,6 @@ class AuthController extends Controller
                 'email_verified_at' => $user->email_verified_at ?? now(),
             ]);
 
-
             Auth::login($user, remember: true);
             $request->session()->regenerate();
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -72,13 +72,6 @@ class AuthController extends Controller
                 'email_verified_at' => $user->email_verified_at ?? now(),
             ]);
 
-            // If existing user has no profile photo, download and store their Google avatar
-            if (! $user->image_path && $googleUser->getAvatar()) {
-                $downloadedPath = $this->downloadGoogleAvatar($googleUser->getAvatar());
-                if ($downloadedPath) {
-                    $user->update(['image_path' => $downloadedPath]);
-                }
-            }
 
             Auth::login($user, remember: true);
             $request->session()->regenerate();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Existing users signing in with Google will no longer have their profile photos automatically downloaded or updated.
  * New users can still receive a Google profile photo during account setup.
  * This keeps existing account profile information unchanged during subsequent Google sign-ins while preserving avatar setup for newly created accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->