### PR TITLE
feat: show appreciators and appreciating lists on locked profiles

### DIFF
--- a/app/Http/Controllers/UserProfileController.php
+++ b/app/Http/Controllers/UserProfileController.php
@@ -78,6 +78,20 @@ class UserProfileController extends Controller
             }
         }
 
+        $appreciators = $user->appreciators()
+            ->select(['users.id', 'users.name', 'users.username', 'users.image_path', 'users.institution', 'users.is_verified'])
+            ->latest('user_appreciations.id')
+            ->take(30)
+            ->get();
+
+        $appreciating = $user->appreciatingUsers()
+            ->select(['users.id', 'users.name', 'users.username', 'users.image_path', 'users.institution', 'users.is_verified'])
+            ->latest('user_appreciations.id')
+            ->take(30)
+            ->get();
+
+            
+
         // Early return if activity is locked for this visitor
         if ($isLocked) {
             return Inertia::render('User/Show', [
@@ -89,6 +103,8 @@ class UserProfileController extends Controller
                 'lockReason' => $lockReason,
                 'activityPrivacy' => $activityPrivacy,
                 'suggestedUsers' => $suggestedUsers,
+                'appreciators' => $appreciators,
+                'appreciating' => $appreciating,
             ]);
         }
 
@@ -117,17 +133,6 @@ class UserProfileController extends Controller
         $totalBlogViews = (int) $user->blogs()->where('is_published', true)->sum('views');
         $sharedResourcesCount = Resource::where('user_id', $user->id)->count();
 
-        $appreciators = $user->appreciators()
-            ->select(['users.id', 'users.name', 'users.username', 'users.image_path', 'users.institution', 'users.is_verified'])
-            ->latest('user_appreciations.id')
-            ->take(30)
-            ->get();
-
-        $appreciating = $user->appreciatingUsers()
-            ->select(['users.id', 'users.name', 'users.username', 'users.image_path', 'users.institution', 'users.is_verified'])
-            ->latest('user_appreciations.id')
-            ->take(30)
-            ->get();
 
         // Recent Community Activities
         $recentForumPosts = ForumPost::where('user_id', $user->id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - User profiles now consistently display appreciators and appreciated users in both locked and unlocked activity views.
  - Relationship information remains available when profile activity is restricted, providing a more consistent viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->