### PR TITLE
feat: display toast notification on form validation error

### DIFF
--- a/resources/js/components/ToastNotification.vue
+++ b/resources/js/components/ToastNotification.vue
@@ -53,7 +53,7 @@ watch(
 
         if (errorKeys.length > 0) {
             addToast(
-                'Validation failed. Please check the form for errors.',
+                'Please fix the errors below to continue.',
                 'error',
             );
         }

--- a/resources/js/components/ToastNotification.vue
+++ b/resources/js/components/ToastNotification.vue
@@ -44,6 +44,22 @@ watch(
     },
     { deep: true, immediate: true },
 );
+
+// Watch Inertia page errors for validation failures
+watch(
+    () => page.props.errors,
+    (errors: any) => {
+        const errorKeys = Object.keys(errors || {});
+
+        if (errorKeys.length > 0) {
+            addToast(
+                'Validation failed. Please check the form for errors.',
+                'error',
+            );
+        }
+    },
+    { deep: true },
+);
 </script>
 
 <template>

--- a/resources/js/components/ToastNotification.vue
+++ b/resources/js/components/ToastNotification.vue
@@ -53,7 +53,7 @@ watch(
 
         if (errorKeys.length > 0) {
             addToast(
-                'Please fix the errors below to continue.',
+                'Failed: Please fix the errors to continue.',
                 'error',
             );
         }


### PR DESCRIPTION
## Description
Watches Inertia's `page.props.errors` in `ToastNotification.vue` to automatically pop an error toast notification when a form submission fails validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an error toast notification when form validation fails.
  - The notification prompts users to check the form for specific errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->